### PR TITLE
Add basic Next.js product page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# react-next-anycase
+# Titanium Cutting Board Site
+
+A simple Next.js website showcasing a titanium cutting board. Styled with Tailwind CSS.
+
+## Development
+
+Install dependencies (requires Node.js) and run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Then open `http://localhost:3000` in your browser.

--- a/components/ProductCard.js
+++ b/components/ProductCard.js
@@ -1,0 +1,14 @@
+export default function ProductCard() {
+  return (
+    <div className="bg-white rounded-lg shadow p-6 max-w-md mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Premium Titanium Cutting Board</h2>
+      <ul className="list-disc list-inside space-y-2 text-gray-700">
+        <li>Crafted from pure titanium with a 1.5 mm thickness for a smooth surface that won't dull knives.</li>
+        <li>Non-porous material resists food juices and odors from garlic or onions.</li>
+        <li>Lightweight at under 0.86 pounds, ideal for camping and travel.</li>
+        <li>Sleek titanium finish with an easy-grip handle for comfortable use.</li>
+        <li>Easy to clean with water or in the dishwasher.</li>
+      </ul>
+    </div>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "titanium-board",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.13",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.26",
+    "tailwindcss": "3.3.2"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import '@/styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+import ProductCard from '@/components/ProductCard'
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>Titanium Cutting Board</title>
+        <meta name="description" content="Premium titanium cutting board" />
+      </Head>
+      <main className="min-h-screen flex items-center justify-center bg-gray-100">
+        <ProductCard />
+      </main>
+    </>
+  )
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: Arial, sans-serif;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- bootstrap minimal Next.js app with Tailwind CSS
- add ProductCard component describing titanium cutting board
- add index page to display the product
- update README with usage instructions

## Testing
- `git status --short`
