### PR TITLE
Add Android-only React Native app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.expo/
+.gradle/
+android-app/google-services.json

--- a/DECLUTTER_GUIDE.md
+++ b/DECLUTTER_GUIDE.md
@@ -1,0 +1,26 @@
+# Declutter Challenge Overview
+
+## Themes
+- Closet
+- Kitchen
+- Bathroom
+- Bedroom
+- Office
+- Digital
+- Paperwork
+- Misc
+
+## Easy Under-10-Minute Task Guidelines
+### DO
+- Focus on a single drawer, shelf, or digital folder.
+- Keep tools and cleaning supplies handy.
+- Set a timer to stay within the time limit.
+- Use boxes or bags for quick sorting: keep, donate, toss.
+- Finish with a quick wipe or sweep of the area.
+
+### DON'T
+- Start large projects you can't finish quickly.
+- Deep-clean or reorganize whole rooms.
+- Buy storage solutions before decluttering.
+- Get distracted by unrelated items.
+- Leave piles or boxes unsorted.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ npm run dev
 ```
 
 Then open `http://localhost:3000` in your browser.
+
+## Android App
+
+An Expo-based React Native project lives in `android-app` for Android only.
+Install dependencies and run on a device or emulator:
+
+```bash
+cd android-app
+npm install
+npm run android
+```
+
+`npm run build` generates a production AAB using EAS.

--- a/android-app/App.tsx
+++ b/android-app/App.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+import { View, Text } from 'react-native';
+import { GlobalProvider } from './src/context/GlobalContext';
+import BannerAdComponent from './src/components/BannerAd';
+import InterstitialManager from './src/ads/InterstitialManager';
+
+const todayTask = { text: 'Declutter one drawer' };
+
+export default function App() {
+  useEffect(() => {
+    InterstitialManager.getInstance();
+  }, []);
+
+  return (
+    <GlobalProvider todayTask={todayTask}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>{todayTask.text}</Text>
+        <BannerAdComponent />
+      </View>
+    </GlobalProvider>
+  );
+}

--- a/android-app/android/app/src/main/AndroidManifest.xml
+++ b/android-app/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.declutterchallenge">
+  <application>
+    <!-- AdMob App ID -->
+    <meta-data
+      android:name="com.google.android.gms.ads.APPLICATION_ID"
+      android:value="ca-app-pub-xxxxxxxxxxxxxxxx~yyyyyyyyyy" />
+  </application>
+</manifest>

--- a/android-app/app.json
+++ b/android-app/app.json
@@ -1,0 +1,12 @@
+{
+  "expo": {
+    "name": "DeclutterChallenge",
+    "slug": "declutter-challenge",
+    "sdkVersion": "50.0.0",
+    "platforms": ["android"],
+    "android": {
+      "googleServicesFile": "./google-services.json",
+      "package": "com.example.declutterchallenge"
+    }
+  }
+}

--- a/android-app/docs/BUILD_CHECKLIST.md
+++ b/android-app/docs/BUILD_CHECKLIST.md
@@ -1,0 +1,7 @@
+# Build Checklist
+
+- [ ] Interstitials limited to one per 2 minutes.
+- [ ] Audio muted on ad load.
+- [ ] AdMob App ID set via `google-services.json`.
+- [ ] Production Ad Unit IDs stored in env variables.
+- [ ] Daily push notification scheduled at 9 AM.

--- a/android-app/eas.json
+++ b/android-app/eas.json
@@ -1,0 +1,9 @@
+{
+  "build": {
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "declutter-challenge-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.tsx",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "build": "eas build -p android --profile production"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "react-native-google-mobile-ads": "^11.0.0",
+    "@react-native-async-storage/async-storage": "^1.18.2",
+    "expo-notifications": "^0.26.0"
+  }
+}

--- a/android-app/src/ads/InterstitialManager.ts
+++ b/android-app/src/ads/InterstitialManager.ts
@@ -1,0 +1,28 @@
+import { InterstitialAd, AdEventType, TestIds } from 'react-native-google-mobile-ads';
+
+class InterstitialManager {
+  private static instance: InterstitialManager;
+  private interstitial: InterstitialAd;
+  private shown = false;
+
+  private constructor() {
+    this.interstitial = InterstitialAd.createForAdRequest(TestIds.INTERSTITIAL);
+    this.interstitial.load();
+  }
+
+  static getInstance() {
+    if (!this.instance) {
+      this.instance = new InterstitialManager();
+    }
+    return this.instance;
+  }
+
+  showOnce() {
+    if (!this.shown) {
+      this.interstitial.show();
+      this.shown = true;
+    }
+  }
+}
+
+export default InterstitialManager;

--- a/android-app/src/components/BannerAd.tsx
+++ b/android-app/src/components/BannerAd.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View } from 'react-native';
+import { BannerAd, BannerAdSize, TestIds } from 'react-native-google-mobile-ads';
+
+type Props = {
+  adUnitId?: string;
+  size?: BannerAdSize;
+};
+
+export default function BannerAdComponent({ adUnitId = TestIds.BANNER, size = BannerAdSize.BANNER }: Props) {
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <BannerAd unitId={adUnitId} size={size} />
+    </View>
+  );
+}

--- a/android-app/src/context/GlobalContext.tsx
+++ b/android-app/src/context/GlobalContext.tsx
@@ -1,0 +1,64 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import InterstitialManager from '../ads/InterstitialManager';
+import useRewardedAd from '../hooks/useRewardedAd';
+
+type ContextValue = {
+  todayTask: { text: string };
+  streak: number;
+  completeTask: () => void;
+  skipWithReward: () => Promise<void>;
+};
+
+const GlobalContext = createContext<ContextValue | undefined>(undefined);
+
+export const GlobalProvider: React.FC<{ todayTask: { text: string } }> = ({ children, todayTask }) => {
+  const [completedDates, setCompletedDates] = useState<string[]>([]);
+  const [streak, setStreak] = useState(0);
+  const [skipTokens, setSkipTokens] = useState(0);
+
+  const showRewarded = useRewardedAd();
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await AsyncStorage.getItem('state');
+      if (data) {
+        const parsed = JSON.parse(data);
+        setCompletedDates(parsed.completedDates || []);
+        setStreak(parsed.streak || 0);
+        setSkipTokens(parsed.skipTokens || 0);
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem('state', JSON.stringify({ completedDates, streak, skipTokens }));
+  }, [completedDates, streak, skipTokens]);
+
+  const completeTask = () => {
+    const today = new Date().toISOString().slice(0, 10);
+    if (!completedDates.includes(today)) {
+      setCompletedDates([...completedDates, today]);
+      setStreak(streak + 1);
+      InterstitialManager.getInstance().showOnce();
+    }
+  };
+
+  const skipWithReward = async () => {
+    await showRewarded();
+    setSkipTokens(skipTokens + 1);
+  };
+
+  return (
+    <GlobalContext.Provider value={{ todayTask, streak, completeTask, skipWithReward }}>
+      {children}
+    </GlobalContext.Provider>
+  );
+};
+
+export const useGlobal = () => {
+  const ctx = useContext(GlobalContext);
+  if (!ctx) throw new Error('GlobalContext missing');
+  return ctx;
+};

--- a/android-app/src/hooks/useRewardedAd.ts
+++ b/android-app/src/hooks/useRewardedAd.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { RewardedAd, RewardedAdEventType, TestIds } from 'react-native-google-mobile-ads';
+
+export default function useRewardedAd() {
+  const [rewarded] = useState(() => RewardedAd.createForAdRequest(TestIds.REWARDED));
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const loadListener = rewarded.addAdEventListener(RewardedAdEventType.LOADED, () => setLoaded(true));
+    const earnListener = rewarded.addAdEventListener(RewardedAdEventType.EARNED_REWARD, () => {});
+    rewarded.load();
+    return () => {
+      loadListener();
+      earnListener();
+    };
+  }, [rewarded]);
+
+  return () =>
+    new Promise<void>(resolve => {
+      if (!loaded) return resolve();
+      const earnListener = rewarded.addAdEventListener(RewardedAdEventType.EARNED_REWARD, () => resolve());
+      rewarded.show();
+      return () => earnListener();
+    });
+}

--- a/daily_prompt_schema.json
+++ b/daily_prompt_schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "dayOffset", "text", "tip", "theme", "timeBucket", "taskType"],
+    "properties": {
+      "id": {"type": "integer", "minimum": 1},
+      "dayOffset": {"type": "integer", "minimum": 1},
+      "text": {"type": "string"},
+      "tip": {"type": "string"},
+      "theme": {"type": "string"},
+      "timeBucket": {"type": "string", "enum": ["<5 min", "5-10 min"]},
+      "taskType": {"type": "string", "enum": ["Dispose", "Organize", "Digital"]}
+    }
+  }
+}

--- a/daily_prompts.json
+++ b/daily_prompts.json
@@ -1,0 +1,812 @@
+[
+  {
+    "id": 1,
+    "dayOffset": 1,
+    "text": "Purge outdated documents",
+    "tip": "Short task, big impact.",
+    "theme": "Office",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 2,
+    "dayOffset": 2,
+    "text": "Remove old calendar events",
+    "tip": "Stay focused!",
+    "theme": "Digital",
+    "timeBucket": "5-10 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 3,
+    "dayOffset": 3,
+    "text": "Bundle magazines to donate",
+    "tip": "Small steps add up!",
+    "theme": "Paperwork",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 4,
+    "dayOffset": 4,
+    "text": "Organize reading stack",
+    "tip": "Keep it simple.",
+    "theme": "Bedroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 5,
+    "dayOffset": 5,
+    "text": "Group hair accessories",
+    "tip": "Clear space, clear mind.",
+    "theme": "Bathroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 6,
+    "dayOffset": 6,
+    "text": "Check batteries in remotes",
+    "tip": "One drawer at a time.",
+    "theme": "Misc",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 7,
+    "dayOffset": 7,
+    "text": "Clear expired fridge items",
+    "tip": "Short task, big impact.",
+    "theme": "Kitchen",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 8,
+    "dayOffset": 8,
+    "text": "Gather empty hangers",
+    "tip": "Keep it simple.",
+    "theme": "Closet",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 9,
+    "dayOffset": 9,
+    "text": "Toss worn-out socks",
+    "tip": "Quick win today.",
+    "theme": "Closet",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 10,
+    "dayOffset": 10,
+    "text": "Sweep front porch",
+    "tip": "Quick win today.",
+    "theme": "Misc",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 11,
+    "dayOffset": 11,
+    "text": "Purge expired coupons",
+    "tip": "Clear space, clear mind.",
+    "theme": "Paperwork",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 12,
+    "dayOffset": 12,
+    "text": "Clean coffee maker carafe",
+    "tip": "Short task, big impact.",
+    "theme": "Kitchen",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 13,
+    "dayOffset": 13,
+    "text": "Clean toothbrush holder",
+    "tip": "Lighten your load.",
+    "theme": "Bathroom",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 14,
+    "dayOffset": 14,
+    "text": "Organize desktop files",
+    "tip": "Short task, big impact.",
+    "theme": "Digital",
+    "timeBucket": "<5 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 15,
+    "dayOffset": 15,
+    "text": "Dust keyboard",
+    "tip": "Clear space, clear mind.",
+    "theme": "Office",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 16,
+    "dayOffset": 16,
+    "text": "Sort jewelry box",
+    "tip": "One drawer at a time.",
+    "theme": "Bedroom",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 17,
+    "dayOffset": 17,
+    "text": "Wipe monitor screen",
+    "tip": "You got this!",
+    "theme": "Office",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 18,
+    "dayOffset": 18,
+    "text": "Clean out toolbox",
+    "tip": "Small steps add up!",
+    "theme": "Misc",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 19,
+    "dayOffset": 19,
+    "text": "Sort one drawer",
+    "tip": "Breathe and declutter.",
+    "theme": "Closet",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 20,
+    "dayOffset": 20,
+    "text": "Check expiration dates",
+    "tip": "Stay focused!",
+    "theme": "Bathroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 21,
+    "dayOffset": 21,
+    "text": "Sort utensil drawer",
+    "tip": "One drawer at a time.",
+    "theme": "Kitchen",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 22,
+    "dayOffset": 22,
+    "text": "Clear nightstand clutter",
+    "tip": "Keep it simple.",
+    "theme": "Bedroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 23,
+    "dayOffset": 23,
+    "text": "Delete unused apps",
+    "tip": "Short task, big impact.",
+    "theme": "Digital",
+    "timeBucket": "5-10 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 24,
+    "dayOffset": 24,
+    "text": "Recycle old catalogs",
+    "tip": "Short task, big impact.",
+    "theme": "Paperwork",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 25,
+    "dayOffset": 25,
+    "text": "Discard old makeup",
+    "tip": "You got this!",
+    "theme": "Bathroom",
+    "timeBucket": "<5 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 26,
+    "dayOffset": 26,
+    "text": "Fold t-shirts neatly",
+    "tip": "One drawer at a time.",
+    "theme": "Closet",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 27,
+    "dayOffset": 27,
+    "text": "Group spices alphabetically",
+    "tip": "Clear space, clear mind.",
+    "theme": "Kitchen",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 28,
+    "dayOffset": 28,
+    "text": "Clear desk inbox tray",
+    "tip": "Quick win today.",
+    "theme": "Paperwork",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 29,
+    "dayOffset": 29,
+    "text": "Dust picture frames",
+    "tip": "Breathe and declutter.",
+    "theme": "Bedroom",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 30,
+    "dayOffset": 30,
+    "text": "Match food storage containers",
+    "tip": "One drawer at a time.",
+    "theme": "Misc",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 31,
+    "dayOffset": 31,
+    "text": "Update phone software",
+    "tip": "Small steps add up!",
+    "theme": "Digital",
+    "timeBucket": "5-10 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 32,
+    "dayOffset": 32,
+    "text": "Remove trash",
+    "tip": "Small steps add up!",
+    "theme": "Office",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 33,
+    "dayOffset": 33,
+    "text": "Discard old condiments",
+    "tip": "Quick win today.",
+    "theme": "Kitchen",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 34,
+    "dayOffset": 34,
+    "text": "Tidy craft supplies",
+    "tip": "Quick win today.",
+    "theme": "Misc",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 35,
+    "dayOffset": 35,
+    "text": "Clean email inbox",
+    "tip": "Lighten your load.",
+    "theme": "Digital",
+    "timeBucket": "<5 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 36,
+    "dayOffset": 36,
+    "text": "Scan medical records",
+    "tip": "Quick win today.",
+    "theme": "Paperwork",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 37,
+    "dayOffset": 37,
+    "text": "Organize belts",
+    "tip": "Quick win today.",
+    "theme": "Closet",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 38,
+    "dayOffset": 38,
+    "text": "Gather loose change",
+    "tip": "Small steps add up!",
+    "theme": "Bedroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 39,
+    "dayOffset": 39,
+    "text": "Organize charging cables",
+    "tip": "Breathe and declutter.",
+    "theme": "Office",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 40,
+    "dayOffset": 40,
+    "text": "Toss empty shampoo bottles",
+    "tip": "One drawer at a time.",
+    "theme": "Bathroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 41,
+    "dayOffset": 41,
+    "text": "Tidy supply shelf",
+    "tip": "Small steps add up!",
+    "theme": "Office",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 42,
+    "dayOffset": 42,
+    "text": "Organize board games",
+    "tip": "Stay focused!",
+    "theme": "Misc",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 43,
+    "dayOffset": 43,
+    "text": "Toss chipped mugs",
+    "tip": "Clear space, clear mind.",
+    "theme": "Kitchen",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 44,
+    "dayOffset": 44,
+    "text": "Sweep closet floor",
+    "tip": "Clear space, clear mind.",
+    "theme": "Closet",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 45,
+    "dayOffset": 45,
+    "text": "Make the bed neatly",
+    "tip": "Stay focused!",
+    "theme": "Bedroom",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 46,
+    "dayOffset": 46,
+    "text": "Sort bookmarks",
+    "tip": "You got this!",
+    "theme": "Digital",
+    "timeBucket": "<5 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 47,
+    "dayOffset": 47,
+    "text": "File paid bills",
+    "tip": "Lighten your load.",
+    "theme": "Paperwork",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 48,
+    "dayOffset": 48,
+    "text": "Replace old towels",
+    "tip": "Stay focused!",
+    "theme": "Bathroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 49,
+    "dayOffset": 49,
+    "text": "Wipe counters",
+    "tip": "Lighten your load.",
+    "theme": "Kitchen",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 50,
+    "dayOffset": 50,
+    "text": "Dust lamps and shades",
+    "tip": "You got this!",
+    "theme": "Bedroom",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 51,
+    "dayOffset": 51,
+    "text": "Change weak passwords",
+    "tip": "Lighten your load.",
+    "theme": "Digital",
+    "timeBucket": "5-10 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 52,
+    "dayOffset": 52,
+    "text": "Match stray shoes",
+    "tip": "One drawer at a time.",
+    "theme": "Closet",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 53,
+    "dayOffset": 53,
+    "text": "Clip important articles",
+    "tip": "Lighten your load.",
+    "theme": "Paperwork",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 54,
+    "dayOffset": 54,
+    "text": "Wipe bathroom mirror",
+    "tip": "Stay focused!",
+    "theme": "Bathroom",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 55,
+    "dayOffset": 55,
+    "text": "Clear desk drawer",
+    "tip": "Quick win today.",
+    "theme": "Office",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 56,
+    "dayOffset": 56,
+    "text": "Gather donation box items",
+    "tip": "Small steps add up!",
+    "theme": "Misc",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 57,
+    "dayOffset": 57,
+    "text": "Straighten dresser top",
+    "tip": "Short task, big impact.",
+    "theme": "Bedroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 58,
+    "dayOffset": 58,
+    "text": "Dust picture ledges",
+    "tip": "Clear space, clear mind.",
+    "theme": "Misc",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 59,
+    "dayOffset": 59,
+    "text": "Group baking tools",
+    "tip": "Short task, big impact.",
+    "theme": "Kitchen",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 60,
+    "dayOffset": 60,
+    "text": "Pick out clothes to repair",
+    "tip": "Stay focused!",
+    "theme": "Closet",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 61,
+    "dayOffset": 61,
+    "text": "Swap worn bath mats",
+    "tip": "Breathe and declutter.",
+    "theme": "Bathroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 62,
+    "dayOffset": 62,
+    "text": "Unsubscribe from newsletters",
+    "tip": "Quick win today.",
+    "theme": "Digital",
+    "timeBucket": "5-10 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 63,
+    "dayOffset": 63,
+    "text": "Archive warranty papers",
+    "tip": "Quick win today.",
+    "theme": "Paperwork",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 64,
+    "dayOffset": 64,
+    "text": "Arrange books by topic",
+    "tip": "Stay focused!",
+    "theme": "Office",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 65,
+    "dayOffset": 65,
+    "text": "Shred junk mail",
+    "tip": "Stay focused!",
+    "theme": "Paperwork",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 66,
+    "dayOffset": 66,
+    "text": "Rename confusing files",
+    "tip": "You got this!",
+    "theme": "Digital",
+    "timeBucket": "<5 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 67,
+    "dayOffset": 67,
+    "text": "Sort pens and markers",
+    "tip": "Stay focused!",
+    "theme": "Office",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 68,
+    "dayOffset": 68,
+    "text": "Empty trash can",
+    "tip": "One drawer at a time.",
+    "theme": "Kitchen",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 69,
+    "dayOffset": 69,
+    "text": "Sort car glove box",
+    "tip": "Short task, big impact.",
+    "theme": "Misc",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 70,
+    "dayOffset": 70,
+    "text": "Group hangers",
+    "tip": "Short task, big impact.",
+    "theme": "Closet",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 71,
+    "dayOffset": 71,
+    "text": "Tidy under-bed storage",
+    "tip": "Clear space, clear mind.",
+    "theme": "Bedroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 72,
+    "dayOffset": 72,
+    "text": "Sort medicine cabinet",
+    "tip": "Quick win today.",
+    "theme": "Bathroom",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 73,
+    "dayOffset": 73,
+    "text": "Wipe sink area",
+    "tip": "Breathe and declutter.",
+    "theme": "Bathroom",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 74,
+    "dayOffset": 74,
+    "text": "Fold spare blankets",
+    "tip": "Breathe and declutter.",
+    "theme": "Bedroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 75,
+    "dayOffset": 75,
+    "text": "Donate one item",
+    "tip": "Small steps add up!",
+    "theme": "Closet",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 76,
+    "dayOffset": 76,
+    "text": "Wipe microwave interior",
+    "tip": "You got this!",
+    "theme": "Kitchen",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 77,
+    "dayOffset": 77,
+    "text": "Recycle empty jars",
+    "tip": "Clear space, clear mind.",
+    "theme": "Misc",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 78,
+    "dayOffset": 78,
+    "text": "Backup photos to cloud",
+    "tip": "Clear space, clear mind.",
+    "theme": "Digital",
+    "timeBucket": "5-10 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 79,
+    "dayOffset": 79,
+    "text": "Label file folders",
+    "tip": "Small steps add up!",
+    "theme": "Paperwork",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 80,
+    "dayOffset": 80,
+    "text": "Recycle old notes",
+    "tip": "Small steps add up!",
+    "theme": "Office",
+    "timeBucket": "5-10 min",
+    "taskType": "Dispose"
+  },
+  {
+    "id": 81,
+    "dayOffset": 81,
+    "text": "Put away laundry pile",
+    "tip": "You got this!",
+    "theme": "Bedroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 82,
+    "dayOffset": 82,
+    "text": "Clear downloads folder",
+    "tip": "Small steps add up!",
+    "theme": "Digital",
+    "timeBucket": "5-10 min",
+    "taskType": "Digital"
+  },
+  {
+    "id": 83,
+    "dayOffset": 83,
+    "text": "Check pantry for duplicates",
+    "tip": "Small steps add up!",
+    "theme": "Kitchen",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 84,
+    "dayOffset": 84,
+    "text": "Clean pet feeding area",
+    "tip": "Keep it simple.",
+    "theme": "Misc",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 85,
+    "dayOffset": 85,
+    "text": "Clear purse or bag",
+    "tip": "You got this!",
+    "theme": "Closet",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 86,
+    "dayOffset": 86,
+    "text": "Sort receipts by month",
+    "tip": "One drawer at a time.",
+    "theme": "Paperwork",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 87,
+    "dayOffset": 87,
+    "text": "File stray papers",
+    "tip": "You got this!",
+    "theme": "Office",
+    "timeBucket": "<5 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 88,
+    "dayOffset": 88,
+    "text": "Rinse shower floor",
+    "tip": "Stay focused!",
+    "theme": "Bathroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 89,
+    "dayOffset": 89,
+    "text": "Empty wastebasket",
+    "tip": "Keep it simple.",
+    "theme": "Bedroom",
+    "timeBucket": "5-10 min",
+    "taskType": "Organize"
+  },
+  {
+    "id": 90,
+    "dayOffset": 90,
+    "text": "Empty recycle bin",
+    "tip": "Lighten your load.",
+    "theme": "Digital",
+    "timeBucket": "5-10 min",
+    "taskType": "Digital"
+  }
+]

--- a/validate.js
+++ b/validate.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync('daily_prompts.json','utf8'));
+let errors = [];
+if (!Array.isArray(data)) errors.push('Root should be array');
+else {
+  data.forEach((item, idx) => {
+    const reqKeys = ['id','dayOffset','text','tip','theme','timeBucket','taskType'];
+    reqKeys.forEach(k => { if(!(k in item)) errors.push(`Item ${idx} missing ${k}`); });
+    if(typeof item.id !== 'number') errors.push(`Item ${idx} id not number`);
+    if(typeof item.dayOffset !== 'number') errors.push(`Item ${idx} dayOffset not number`);
+    if(typeof item.text !== 'string') errors.push(`Item ${idx} text not string`);
+    if(typeof item.tip !== 'string') errors.push(`Item ${idx} tip not string`);
+    if(typeof item.theme !== 'string') errors.push(`Item ${idx} theme not string`);
+    if(!['<5 min','5-10 min'].includes(item.timeBucket)) errors.push(`Item ${idx} bad timeBucket`);
+    if(!['Dispose','Organize','Digital'].includes(item.taskType)) errors.push(`Item ${idx} bad taskType`);
+  });
+}
+if(errors.length){
+  console.error('Validation errors:\n' + errors.join('\n'));
+  process.exit(1);
+} else {
+  console.log('JSON validation passed');
+}


### PR DESCRIPTION
## Summary
- add Expo mobile project under `android-app`
- provide AdMob example components and global context
- document Android workflow in README
- ignore build artifacts and google services file

## Testing
- `node validate.js`
