### PR TITLE
Add AdMob PDF viewer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ npm run android
 ```
 
 `npm run build` generates a production AAB using EAS.
+
+The Android project integrates AdMob ads via `react-native-google-mobile-ads` and
+includes a simple PDF viewer component powered by `react-native-pdf`.

--- a/android-app/App.tsx
+++ b/android-app/App.tsx
@@ -3,6 +3,7 @@ import { View, Text } from 'react-native';
 import { GlobalProvider } from './src/context/GlobalContext';
 import BannerAdComponent from './src/components/BannerAd';
 import InterstitialManager from './src/ads/InterstitialManager';
+import PDFViewer from './src/components/PDFViewer';
 
 const todayTask = { text: 'Declutter one drawer' };
 
@@ -16,6 +17,9 @@ export default function App() {
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         <Text>{todayTask.text}</Text>
         <BannerAdComponent />
+        <View style={{ height: 400, width: '100%', marginTop: 20 }}>
+          <PDFViewer uri="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf" />
+        </View>
       </View>
     </GlobalProvider>
   );

--- a/android-app/docs/BUILD_CHECKLIST.md
+++ b/android-app/docs/BUILD_CHECKLIST.md
@@ -5,3 +5,4 @@
 - [ ] AdMob App ID set via `google-services.json`.
 - [ ] Production Ad Unit IDs stored in env variables.
 - [ ] Daily push notification scheduled at 9 AM.
+- [ ] PDF viewer renders sample document.

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -14,6 +14,8 @@
     "react-native": "0.73.0",
     "react-native-google-mobile-ads": "^11.0.0",
     "@react-native-async-storage/async-storage": "^1.18.2",
-    "expo-notifications": "^0.26.0"
+    "expo-notifications": "^0.26.0",
+    "react-native-webview": "^13.5.0",
+    "react-native-pdf": "^6.6.2"
   }
 }

--- a/android-app/src/components/PDFViewer.tsx
+++ b/android-app/src/components/PDFViewer.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Dimensions } from 'react-native';
+import Pdf from 'react-native-pdf';
+
+export default function PDFViewer({ uri }: { uri: string }) {
+  const source = { uri };
+  return (
+    <View style={{ flex: 1 }}>
+      <Pdf
+        source={source}
+        style={{ flex: 1, width: Dimensions.get('window').width }}
+      />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate AdMob and PDF viewer docs
- add PDFViewer component using `react-native-pdf`
- display PDF in `App.tsx`
- document PDF viewer in build checklist

## Testing
- `git status --short`