### PR TITLE
Add Mosaic Puzzle Game RN project

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ npm run android
 
 The Android project integrates AdMob ads via `react-native-google-mobile-ads` and
 includes a simple PDF viewer component powered by `react-native-pdf`.
+
+## Mosaic Puzzle Game
+
+Another React Native project using version 0.74 lives in `mosaic-puzzle-game`.
+Run it on Android with the same commands:
+
+```bash
+cd mosaic-puzzle-game
+npm install
+npm run android
+```
+
+This app displays all text in English and integrates Google Mobile Ads
+(`react-native-google-mobile-ads` @14.7.2).

--- a/mosaic-puzzle-game/App.tsx
+++ b/mosaic-puzzle-game/App.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+import { View, Text, Button } from 'react-native';
+import BannerAdComponent from './src/components/BannerAd';
+import InterstitialManager from './src/ads/InterstitialManager';
+
+export default function App() {
+  useEffect(() => {
+    // 최초 한번 전면 광고 로드
+    InterstitialManager.getInstance();
+  }, []);
+
+  // 버튼 클릭 시 광고를 보여줌
+  const showAd = () => InterstitialManager.getInstance().showOnce();
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Welcome to Mosaic Puzzle Game!</Text>
+      <Button title="Start" onPress={showAd} />
+      <BannerAdComponent />
+    </View>
+  );
+}

--- a/mosaic-puzzle-game/android/app/src/main/AndroidManifest.xml
+++ b/mosaic-puzzle-game/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.mosaicpuzzlegame">
+  <application>
+    <!-- AdMob App ID -->
+    <meta-data
+      android:name="com.google.android.gms.ads.APPLICATION_ID"
+      android:value="ca-app-pub-xxxxxxxxxxxxxxxx~yyyyyyyyyy" />
+  </application>
+</manifest>

--- a/mosaic-puzzle-game/app.json
+++ b/mosaic-puzzle-game/app.json
@@ -1,0 +1,12 @@
+{
+  "expo": {
+    "name": "모자이크 퍼즐 게임",
+    "slug": "mosaic-puzzle-game",
+    "sdkVersion": "50.0.0",
+    "platforms": ["android"],
+    "android": {
+      "googleServicesFile": "./google-services.json",
+      "package": "com.example.mosaicpuzzlegame"
+    }
+  }
+}

--- a/mosaic-puzzle-game/docs/BUILD_CHECKLIST.md
+++ b/mosaic-puzzle-game/docs/BUILD_CHECKLIST.md
@@ -1,0 +1,7 @@
+# Build Checklist
+
+- [ ] Interstitials limited to one per 2 minutes.
+- [ ] Audio muted on ad load.
+- [ ] AdMob App ID set via `google-services.json`.
+- [ ] Production Ad Unit IDs stored in env variables.
+- [ ] App text shown only in English.

--- a/mosaic-puzzle-game/eas.json
+++ b/mosaic-puzzle-game/eas.json
@@ -1,0 +1,9 @@
+{
+  "build": {
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}

--- a/mosaic-puzzle-game/package.json
+++ b/mosaic-puzzle-game/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mosaic-puzzle-game",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.tsx",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "build": "eas build -p android --profile production"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.74.0",
+    "react-native-google-mobile-ads": "^14.7.2"
+  }
+}

--- a/mosaic-puzzle-game/src/ads/InterstitialManager.ts
+++ b/mosaic-puzzle-game/src/ads/InterstitialManager.ts
@@ -1,0 +1,30 @@
+import { InterstitialAd, TestIds } from 'react-native-google-mobile-ads';
+
+class InterstitialManager {
+  private static instance: InterstitialManager;
+  private interstitial: InterstitialAd;
+  private shown = false;
+
+  private constructor() {
+    // 테스트용 전면 광고 로드
+    this.interstitial = InterstitialAd.createForAdRequest(TestIds.INTERSTITIAL);
+    this.interstitial.load();
+  }
+
+  static getInstance() {
+    if (!this.instance) {
+      this.instance = new InterstitialManager();
+    }
+    return this.instance;
+  }
+
+  showOnce() {
+    // 한 번만 전면 광고 노출
+    if (!this.shown) {
+      this.interstitial.show();
+      this.shown = true;
+    }
+  }
+}
+
+export default InterstitialManager;

--- a/mosaic-puzzle-game/src/components/BannerAd.tsx
+++ b/mosaic-puzzle-game/src/components/BannerAd.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View } from 'react-native';
+import { BannerAd, BannerAdSize, TestIds } from 'react-native-google-mobile-ads';
+
+type Props = {
+  adUnitId?: string;
+  size?: BannerAdSize;
+};
+
+export default function BannerAdComponent({ adUnitId = TestIds.BANNER, size = BannerAdSize.BANNER }: Props) {
+  // 배너 광고 컴포넌트
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <BannerAd unitId={adUnitId} size={size} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add new React Native project `mosaic-puzzle-game`
- configure project for RN 0.74 and google mobile ads v14
- provide simple ad-supported app in English
- document new project in README

## Testing
- `node validate.js`