### PR TITLE
Add simple ChatGPT style chat page

### DIFF
--- a/components/ChatBubble.js
+++ b/components/ChatBubble.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function ChatBubble({ message }) {
+  const isUser = message.role === 'user';
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-2`}>
+      <div className={`rounded-lg p-2 max-w-xs whitespace-pre-wrap ${isUser ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-900'}`}>
+        {message.text}
+      </div>
+    </div>
+  );
+}

--- a/pages/chat.js
+++ b/pages/chat.js
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import ChatBubble from '@/components/ChatBubble';
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState([
+    { role: 'bot', text: 'Hello, how can I help you today?' }
+  ]);
+  const [input, setInput] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input };
+    const botMsg = { role: 'bot', text: `You said: ${input}` };
+    setMessages([...messages, userMsg, botMsg]);
+    setInput('');
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Chat</title>
+      </Head>
+      <div className="flex flex-col h-screen">
+        <div className="flex-1 overflow-y-auto p-4 bg-gray-50">
+          {messages.map((msg, idx) => (
+            <ChatBubble key={idx} message={msg} />
+          ))}
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t flex bg-white">
+          <input
+            type="text"
+            className="flex-1 border rounded p-2 mr-2"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type your message..."
+          />
+          <button type="submit" className="bg-blue-500 text-white rounded px-4">
+            Send
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `ChatBubble` component
- create a `/chat` page with simple message input

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a5b931b6483289cb84466dcd0526c