### PR TITLE
Add ChatGPT UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,14 @@ npm run android
 ```
 
 Google Mobile Ads (`react-native-google-mobile-ads` @15.2.0) is integrated and all user text is in English.
+
+## ChatGPT UI
+
+A simple chat interface using OpenAI's ChatGPT API is available at `/chatgpt`.
+Set the `OPENAI_API_KEY` environment variable before starting the dev server:
+
+```bash
+OPENAI_API_KEY=your-key npm run dev
+```
+
+Then open `http://localhost:3000/chatgpt` in your browser.

--- a/pages/api/chatgpt.js
+++ b/pages/api/chatgpt.js
@@ -1,0 +1,34 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'Missing OPENAI_API_KEY' });
+    return;
+  }
+  const { messages } = req.body;
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages,
+      }),
+    });
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(errText);
+    }
+    const data = await response.json();
+    const text = data.choices?.[0]?.message?.content || '';
+    res.status(200).json({ text });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/pages/chatgpt.js
+++ b/pages/chatgpt.js
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import ChatBubble from '@/components/ChatBubble';
+
+export default function ChatGptPage() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text }))
+        }),
+      });
+      const data = await res.json();
+      const botMsg = { role: 'assistant', text: data.text || 'No response' };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      const errorMsg = { role: 'assistant', text: 'Error: ' + err.message };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>ChatGPT UI</title>
+      </Head>
+      <div className="flex flex-col h-screen">
+        <div className="flex-1 overflow-y-auto bg-gray-100">
+          {messages.map((msg, idx) => (
+            <ChatBubble key={idx} message={msg} />
+          ))}
+          {loading && (
+            <ChatBubble message={{ role: 'assistant', text: 'Loading...' }} />
+          )}
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white flex gap-2">
+          <textarea
+            rows={1}
+            className="w-full border border-gray-300 rounded p-2 resize-none"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Send a message"
+          />
+          <button type="submit" className="bg-blue-500 text-white rounded px-4 py-2" disabled={loading}>
+            Send
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route to talk to OpenAI ChatGPT
- add simple chat page using the new API
- document the ChatGPT UI in the README

## Testing
- `node validate.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683cd93107c48328bda538a16194fc8e