### PR TITLE
Add QuickTipApp example

### DIFF
--- a/QuickTipApp/App.tsx
+++ b/QuickTipApp/App.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import BannerAdComponent from './src/components/BannerAd';
+
+export default function App() {
+  // 상태 관리: 금액, 팁 퍼센트, 계산 결과
+  const [bill, setBill] = useState('');
+  const [percent, setPercent] = useState('15');
+  const billNum = parseFloat(bill) || 0;
+  const percentNum = parseFloat(percent) || 0;
+  const tip = billNum * (percentNum / 100);
+  const total = billNum + tip;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Tip Calculator</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Bill Amount"
+        keyboardType="numeric"
+        value={bill}
+        onChangeText={setBill}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Tip %"
+        keyboardType="numeric"
+        value={percent}
+        onChangeText={setPercent}
+      />
+      <Button title="Calculate" onPress={() => {}} />
+      <Text style={styles.result}>Tip: ${tip.toFixed(2)}</Text>
+      <Text style={styles.result}>Total: ${total.toFixed(2)}</Text>
+      <View style={styles.banner}>
+        <BannerAdComponent />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 16 },
+  title: { fontSize: 24, marginBottom: 16 },
+  input: { width: '80%', padding: 8, borderWidth: 1, borderColor: '#ccc', marginBottom: 12 },
+  result: { fontSize: 18, marginTop: 8 },
+  banner: { position: 'absolute', bottom: 0, width: '100%' },
+});

--- a/QuickTipApp/android/app/src/main/AndroidManifest.xml
+++ b/QuickTipApp/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.quicktipapp">
+  <application>
+    <!-- AdMob App ID -->
+    <meta-data
+      android:name="com.google.android.gms.ads.APPLICATION_ID"
+      android:value="ca-app-pub-xxxxxxxxxxxxxxxx~yyyyyyyyyy" />
+  </application>
+</manifest>

--- a/QuickTipApp/app.json
+++ b/QuickTipApp/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "QuickTipApp",
+  "displayName": "Quick Tip App"
+}

--- a/QuickTipApp/index.js
+++ b/QuickTipApp/index.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/QuickTipApp/package.json
+++ b/QuickTipApp/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "quick-tip-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.78.2",
+    "react-native-google-mobile-ads": "^15.2.0"
+  }
+}

--- a/QuickTipApp/src/components/BannerAd.tsx
+++ b/QuickTipApp/src/components/BannerAd.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View } from 'react-native';
+import { BannerAd, BannerAdSize, TestIds } from 'react-native-google-mobile-ads';
+
+type Props = {
+  adUnitId?: string;
+  size?: BannerAdSize;
+};
+
+export default function BannerAdComponent({ adUnitId = TestIds.BANNER, size = BannerAdSize.BANNER }: Props) {
+  // 배너 광고 컴포넌트
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <BannerAd unitId={adUnitId} size={size} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple Android-only React Native project `QuickTipApp`
- show a Tip Calculator screen in English
- integrate banner ads using `react-native-google-mobile-ads` 15.2.0

## Testing
- `npm test --prefix QuickTipApp` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_683dc1a9155c8328af16a0097c4614c7