### PR TITLE
Add GPT UI page with model choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ OPENAI_API_KEY=your-key npm run dev
 ```
 
 Then open `http://localhost:3000/chatgpt` in your browser.
+
+A variant at `/gpt` lets you choose the OpenAI model (e.g. `gpt-4`).

--- a/pages/api/chatgpt.js
+++ b/pages/api/chatgpt.js
@@ -8,7 +8,8 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Missing OPENAI_API_KEY' });
     return;
   }
-  const { messages } = req.body;
+  const { messages, model } = req.body;
+  const chosenModel = typeof model === 'string' && model.trim() ? model.trim() : 'gpt-3.5-turbo';
   try {
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -17,7 +18,7 @@ export default async function handler(req, res) {
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
+        model: chosenModel,
         messages,
       }),
     });

--- a/pages/gpt.js
+++ b/pages/gpt.js
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import ChatBubble from '@/components/ChatBubble';
+
+const MODELS = ['gpt-3.5-turbo', 'gpt-4'];
+
+export default function GptUIPage() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [model, setModel] = useState(MODELS[0]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model,
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text }))
+        }),
+      });
+      const data = await res.json();
+      const botMsg = { role: 'assistant', text: data.text || 'No response' };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      const errorMsg = { role: 'assistant', text: 'Error: ' + err.message };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>GPT UI</title>
+      </Head>
+      <div className="flex flex-col h-screen">
+        <div className="flex-1 overflow-y-auto bg-gray-100">
+          {messages.map((msg, idx) => (
+            <ChatBubble key={idx} message={msg} />
+          ))}
+          {loading && (
+            <ChatBubble message={{ role: 'assistant', text: 'Loading...' }} />
+          )}
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white flex gap-2 items-start">
+          <select
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            className="border border-gray-300 rounded p-2"
+          >
+            {MODELS.map((m) => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+          <textarea
+            rows={1}
+            className="w-full border border-gray-300 rounded p-2 resize-none"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Send a message"
+          />
+          <button type="submit" className="bg-blue-500 text-white rounded px-4 py-2" disabled={loading}>
+            Send
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- allow specifying model in `pages/api/chatgpt.js`
- document `/gpt` page in README
- add `/gpt` page to choose GPT model

## Testing
- `node validate.js`

------
https://chatgpt.com/codex/tasks/task_e_683f5291f0648328a5cd95dc53dc46a3