### PR TITLE
Fix module path imports

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["components/*"],
+      "@/styles/*": ["styles/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- support `@/components` and `@/styles` imports by adding a `jsconfig.json`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477b88c4e4832895e5ae304609535f