### PR TITLE
Improve ChatGPT UI accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,14 @@ To run it locally:
 3. Open `http://localhost:3000/chatgpt` in your browser.
 
 You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
+
+### UX Design Tips
+
+Here are a few guidelines that informed the simple chat interface:
+
+1. **Simplicity** – Keep the layout focused on the conversation with minimal clutter.
+2. **Visual hierarchy** – Differentiate user and assistant messages with distinct backgrounds.
+3. **Accessibility** – Ensure readable fonts and keyboard navigation. The input area automatically receives focus.
+4. **Feedback** – While waiting for a reply, a loading message appears and the send button is disabled.
+5. **Scrolling behavior** – New messages scroll into view so context is maintained.
+6. **Customization** – Choose a different model on the `/gpt` page.

--- a/pages/chatgpt.js
+++ b/pages/chatgpt.js
@@ -7,12 +7,25 @@ export default function ChatGptPage() {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
   const endRef = useRef(null);
+  const inputRef = useRef(null);
 
   useEffect(() => {
     if (endRef.current) {
       endRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -57,13 +70,19 @@ export default function ChatGptPage() {
         </div>
         <form onSubmit={handleSubmit} className="p-4 border-t bg-white flex gap-2">
           <textarea
+            ref={inputRef}
             rows={1}
             className="w-full border border-gray-300 rounded p-2 resize-none"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Send a message"
           />
-          <button type="submit" className="bg-blue-500 text-white rounded px-4 py-2" disabled={loading}>
+          <button
+            type="submit"
+            className="bg-blue-500 text-white rounded px-4 py-2"
+            disabled={loading}
+            aria-label="Send message"
+          >
             Send
           </button>
         </form>

--- a/pages/gpt.js
+++ b/pages/gpt.js
@@ -10,12 +10,25 @@ export default function GptUIPage() {
   const [model, setModel] = useState(MODELS[0]);
   const [loading, setLoading] = useState(false);
   const endRef = useRef(null);
+  const inputRef = useRef(null);
 
   useEffect(() => {
     if (endRef.current) {
       endRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -70,13 +83,19 @@ export default function GptUIPage() {
             ))}
           </select>
           <textarea
+            ref={inputRef}
             rows={1}
             className="w-full border border-gray-300 rounded p-2 resize-none"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Send a message"
           />
-          <button type="submit" className="bg-blue-500 text-white rounded px-4 py-2" disabled={loading}>
+          <button
+            type="submit"
+            className="bg-blue-500 text-white rounded px-4 py-2"
+            disabled={loading}
+            aria-label="Send message"
+          >
             Send
           </button>
         </form>


### PR DESCRIPTION
## Summary
- autofocus the input for a smoother workflow
- add aria labels and keep focus after loading
- document some simple UX guidelines in the README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ce3b24108328b9b5baea9c15e849