### PR TITLE
Add persistent ChatGPT UI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ To run it locally:
 3. Open `http://localhost:3000/chatgpt` in your browser.
 
 You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
+For conversations that persist across page reloads, visit `/chatgpt-ui`.
 
 Key files implementing the chat interface:
 
@@ -77,6 +78,7 @@ Key files implementing the chat interface:
 - `pages/api/chatgpt.js` – API route that sends prompts to OpenAI.
 - `components/ChatBubble.js` – the message bubble component.
 - `pages/gpt.js` – variant with a model selector.
+- `pages/chatgpt-ui.js` – version that stores messages in local storage.
 
 Below is a short excerpt from the `handleSubmit` function in
 `pages/chatgpt.js`. It shows how each message is sent to the `/api/chatgpt`

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -1,0 +1,115 @@
+import { useState, useRef, useEffect } from 'react';
+import Head from 'next/head';
+import ChatBubble from '@/components/ChatBubble';
+
+const STORAGE_KEY = 'chatgptMessages';
+
+export default function ChatGptUIPersist() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef(null);
+  const inputRef = useRef(null);
+
+  // Load messages from local storage on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        setMessages(JSON.parse(saved));
+      }
+    } catch (err) {
+      console.error('Failed to load messages', err);
+    }
+  }, []);
+
+  // Save messages to local storage whenever they change
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+    } catch (err) {
+      console.error('Failed to save messages', err);
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text }))
+        }),
+      });
+      const data = await res.json();
+      const botMsg = { role: 'assistant', text: data.text || 'No response' };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      const errorMsg = { role: 'assistant', text: 'Error: ' + err.message };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>ChatGPT UI (Persistent)</title>
+      </Head>
+      <div className="flex flex-col h-screen">
+        <div className="flex-1 overflow-y-auto bg-gray-100 p-4">
+          {messages.map((msg, idx) => (
+            <ChatBubble key={idx} message={msg} />
+          ))}
+          {loading && (
+            <ChatBubble message={{ role: 'assistant', text: 'Loading...' }} />
+          )}
+          <div ref={endRef} />
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white flex gap-2">
+          <textarea
+            ref={inputRef}
+            rows={1}
+            className="w-full border border-gray-300 rounded p-2 resize-none"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Send a message"
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white rounded px-4 py-2"
+            disabled={loading}
+            aria-label="Send message"
+          >
+            Send
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create `pages/chatgpt-ui.js` that stores messages in local storage
- document the new persistent chat UI in README

## Testing
- `node validate.js`

------
https://chatgpt.com/codex/tasks/task_e_6850dc4b64a48328a7a7d066f56dd653