### PR TITLE
Enable dark mode toggle for chat UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To run it locally:
 
 You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
 For conversations that persist across page reloads, visit `/chatgpt-ui`.
+All chat pages now include a **Dark Mode** toggle in the header.
 
 Key files implementing the chat interface:
 

--- a/components/ChatBubble.js
+++ b/components/ChatBubble.js
@@ -4,7 +4,7 @@ export default function ChatBubble({ message }) {
   const isUser = message.role === 'user';
 
   return (
-    <div className={isUser ? 'bg-white' : 'bg-gray-50'}>
+    <div className={isUser ? 'bg-white dark:bg-gray-900' : 'bg-gray-50 dark:bg-gray-800'}>
       <div
         className={`max-w-2xl mx-auto py-3 flex ${
           isUser ? 'justify-end' : 'justify-start'
@@ -17,8 +17,8 @@ export default function ChatBubble({ message }) {
           <p
             className={`rounded-md px-4 py-2 border whitespace-pre-wrap ${
               isUser
-                ? 'bg-gray-100 text-gray-900 border-gray-300'
-                : 'bg-white text-gray-900 border-gray-200'
+                ? 'bg-gray-100 text-gray-900 border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700'
+                : 'bg-white text-gray-900 border-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600'
             }`}
           >
             {message.text}

--- a/components/DarkModeToggle.js
+++ b/components/DarkModeToggle.js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+export default function DarkModeToggle() {
+  const [enabled, setEnabled] = useState(false);
+
+  // load saved setting
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('darkMode');
+      if (saved === 'true') {
+        setEnabled(true);
+        document.documentElement.classList.add('dark');
+      }
+    } catch (err) {
+      // ignore errors
+    }
+  }, []);
+
+  // toggle class on document
+  useEffect(() => {
+    if (enabled) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    try {
+      localStorage.setItem('darkMode', enabled ? 'true' : 'false');
+    } catch (err) {
+      // ignore errors
+    }
+  }, [enabled]);
+
+  return (
+    <button
+      onClick={() => setEnabled(!enabled)}
+      className="border px-2 py-1 rounded text-sm bg-white dark:bg-gray-700 dark:text-gray-100"
+      aria-label="Toggle dark mode"
+    >
+      {enabled ? 'Light Mode' : 'Dark Mode'}
+    </button>
+  );
+}

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import ChatBubble from '@/components/ChatBubble';
+import DarkModeToggle from '@/components/DarkModeToggle';
 
 const STORAGE_KEY = 'chatgptMessages';
 
@@ -81,8 +82,11 @@ export default function ChatGptUIPersist() {
       <Head>
         <title>ChatGPT UI (Persistent)</title>
       </Head>
-      <div className="flex flex-col h-screen">
-        <div className="flex-1 overflow-y-auto bg-gray-100 p-4">
+      <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+          <DarkModeToggle />
+        </div>
+        <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
           {messages.map((msg, idx) => (
             <ChatBubble key={idx} message={msg} />
           ))}
@@ -91,18 +95,18 @@ export default function ChatGptUIPersist() {
           )}
           <div ref={endRef} />
         </div>
-        <form onSubmit={handleSubmit} className="p-4 border-t bg-white flex gap-2">
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
           <textarea
             ref={inputRef}
             rows={1}
-            className="w-full border border-gray-300 rounded p-2 resize-none"
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Send a message"
           />
           <button
             type="submit"
-            className="bg-blue-500 text-white rounded px-4 py-2"
+            className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50"
             disabled={loading}
             aria-label="Send message"
           >

--- a/pages/chatgpt.js
+++ b/pages/chatgpt.js
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import ChatBubble from '@/components/ChatBubble';
+import DarkModeToggle from '@/components/DarkModeToggle';
 
 export default function ChatGptPage() {
   const [messages, setMessages] = useState([]);
@@ -58,8 +59,11 @@ export default function ChatGptPage() {
       <Head>
         <title>ChatGPT UI</title>
       </Head>
-      <div className="flex flex-col h-screen">
-        <div className="flex-1 overflow-y-auto bg-gray-100 p-4">
+      <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+          <DarkModeToggle />
+        </div>
+        <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
           {messages.map((msg, idx) => (
             <ChatBubble key={idx} message={msg} />
           ))}
@@ -68,18 +72,18 @@ export default function ChatGptPage() {
           )}
           <div ref={endRef} />
         </div>
-        <form onSubmit={handleSubmit} className="p-4 border-t bg-white flex gap-2">
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
           <textarea
             ref={inputRef}
             rows={1}
-            className="w-full border border-gray-300 rounded p-2 resize-none"
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Send a message"
           />
           <button
             type="submit"
-            className="bg-blue-500 text-white rounded px-4 py-2"
+            className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50"
             disabled={loading}
             aria-label="Send message"
           >

--- a/pages/gpt.js
+++ b/pages/gpt.js
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import ChatBubble from '@/components/ChatBubble';
+import DarkModeToggle from '@/components/DarkModeToggle';
 
 const MODELS = ['gpt-3.5-turbo', 'gpt-4'];
 
@@ -62,8 +63,11 @@ export default function GptUIPage() {
       <Head>
         <title>GPT UI</title>
       </Head>
-      <div className="flex flex-col h-screen">
-        <div className="flex-1 overflow-y-auto bg-gray-100 p-4">
+      <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+          <DarkModeToggle />
+        </div>
+        <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
           {messages.map((msg, idx) => (
             <ChatBubble key={idx} message={msg} />
           ))}
@@ -72,11 +76,11 @@ export default function GptUIPage() {
           )}
           <div ref={endRef} />
         </div>
-        <form onSubmit={handleSubmit} className="p-4 border-t bg-white flex gap-2 items-start">
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2 items-start">
           <select
             value={model}
             onChange={(e) => setModel(e.target.value)}
-            className="border border-gray-300 rounded p-2"
+            className="border border-gray-300 dark:border-gray-700 rounded p-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
           >
             {MODELS.map((m) => (
               <option key={m} value={m}>{m}</option>
@@ -85,14 +89,14 @@ export default function GptUIPage() {
           <textarea
             ref={inputRef}
             rows={1}
-            className="w-full border border-gray-300 rounded p-2 resize-none"
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Send a message"
           />
           <button
             type="submit"
-            className="bg-blue-500 text-white rounded px-4 py-2"
+            className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50"
             disabled={loading}
             aria-label="Send message"
           >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}"


### PR DESCRIPTION
## Summary
- add a DarkModeToggle component
- support dark mode in message bubbles
- incorporate dark mode toggle in chat pages
- enable class-based dark mode in Tailwind
- mention dark mode toggle in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852171dc3f08328a66576cb635afa9f