### PR TITLE
Set ChatGPT UI as homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Google Mobile Ads (`react-native-google-mobile-ads` @15.2.0) is integrated and a
 
 ## ChatGPT UI
 
-A simple chat interface using OpenAI's ChatGPT API is available at `/chatgpt`.
+The site now defaults to a simple ChatGPT interface on the home page (`/`). You
+can also access it directly via `/chatgpt`.
 
 To run it locally:
 
@@ -67,7 +68,7 @@ To run it locally:
    ```bash
    npm run dev
    ```
-3. Open `http://localhost:3000/chatgpt` in your browser.
+3. Open `http://localhost:3000` in your browser.
 
 You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
 For conversations that persist across page reloads, visit `/chatgpt-ui`.

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,16 +1,2 @@
-import Head from 'next/head'
-import ProductCard from '@/components/ProductCard'
-
-export default function Home() {
-  return (
-    <>
-      <Head>
-        <title>Titanium Cutting Board</title>
-        <meta name="description" content="Premium titanium cutting board" />
-      </Head>
-      <main className="min-h-screen flex items-center justify-center bg-gray-100">
-        <ProductCard />
-      </main>
-    </>
-  )
-}
+// Reuse the existing ChatGPT page as the landing page
+export { default } from './chatgpt'


### PR DESCRIPTION
## Summary
- make the ChatGPT interface the landing page
- update documentation accordingly

## Testing
- `node validate.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68536eef40988328b587edf4e0ac9c43