### PR TITLE
Add Korean ChatGPT UI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To run it locally:
 
 You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
 For conversations that persist across page reloads, visit `/chatgpt-ui`.
+A Korean interface is available at `/chatgpt-ko`.
 All chat pages now include a **Dark Mode** toggle in the header.
 
 Key files implementing the chat interface:
@@ -81,6 +82,7 @@ Key files implementing the chat interface:
 - `components/ChatBubble.js` – the message bubble component.
 - `pages/gpt.js` – variant with a model selector.
 - `pages/chatgpt-ui.js` – version that stores messages in local storage.
+- `pages/chatgpt-ko.js` – Korean language interface.
 
 Below is a short excerpt from the `handleSubmit` function in
 `pages/chatgpt.js`. It shows how each message is sent to the `/api/chatgpt`

--- a/components/ChatBubbleKo.js
+++ b/components/ChatBubbleKo.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default function ChatBubble({ message }) {
+  const isUser = message.role === 'user';
+
+  return (
+    <div className={isUser ? 'bg-white dark:bg-gray-900' : 'bg-gray-50 dark:bg-gray-800'}>
+      <div
+        className={`max-w-2xl mx-auto py-3 flex ${
+          isUser ? 'justify-end' : 'justify-start'
+        }`}
+      >
+        <div className="space-y-1 max-w-full">
+          <span className="text-xs text-gray-500">
+            {isUser ? '사용자' : '어시스턴트'}
+          </span>
+          <p
+            className={`rounded-md px-4 py-2 border whitespace-pre-wrap ${
+              isUser
+                ? 'bg-gray-100 text-gray-900 border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700'
+                : 'bg-white text-gray-900 border-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600'
+            }`}
+          >
+            {message.text}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/chatgpt-ko.js
+++ b/pages/chatgpt-ko.js
@@ -1,0 +1,119 @@
+import { useState, useRef, useEffect } from 'react';
+import Head from 'next/head';
+import ChatBubble from '@/components/ChatBubbleKo';
+import DarkModeToggle from '@/components/DarkModeToggle';
+
+const STORAGE_KEY = 'chatgptMessages';
+
+export default function ChatGptKoPage() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef(null);
+  const inputRef = useRef(null);
+
+  // Load messages from local storage on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        setMessages(JSON.parse(saved));
+      }
+    } catch (err) {
+      console.error('Failed to load messages', err);
+    }
+  }, []);
+
+  // Save messages to local storage whenever they change
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+    } catch (err) {
+      console.error('Failed to save messages', err);
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text }))
+        }),
+      });
+      const data = await res.json();
+      const botMsg = { role: 'assistant', text: data.text || 'No response' };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      const errorMsg = { role: 'assistant', text: 'Error: ' + err.message };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>ChatGPT UI (한국어)</title>
+      </Head>
+      <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+          <DarkModeToggle />
+        </div>
+        <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
+          {messages.map((msg, idx) => (
+            <ChatBubble key={idx} message={msg} />
+          ))}
+          {loading && (
+            <ChatBubble message={{ role: 'assistant', text: '로딩 중...' }} />
+          )}
+          <div ref={endRef} />
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
+          <textarea
+            ref={inputRef}
+            rows={1}
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="메시지를 입력하세요"
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50"
+            disabled={loading}
+            aria-label="메시지 전송"
+          >
+            전송
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add ChatBubbleKo component with Korean labels
- implement `pages/chatgpt-ko.js` for a Korean ChatGPT interface
- document the new page in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fee800d883288c8717a0502df991