### PR TITLE
Add streaming ChatGPT UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Key files implementing the chat interface:
 - `pages/gpt.js` – variant with a model selector.
 - `pages/chatgpt-ui.js` – version that stores messages in local storage.
 - `pages/chatgpt-ko.js` – Korean language interface.
+- `pages/chatgpt-stream.js` – streams responses token by token.
+- `pages/api/chatgpt-stream.js` – API route powering the streaming UI.
 
 Below is a short excerpt from the `handleSubmit` function in
 `pages/chatgpt.js`. It shows how each message is sent to the `/api/chatgpt`

--- a/pages/api/chatgpt-stream.js
+++ b/pages/api/chatgpt-stream.js
@@ -1,0 +1,48 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).end('Method not allowed');
+    return;
+  }
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    res.status(500).end('Missing OPENAI_API_KEY');
+    return;
+  }
+  const { messages, model } = req.body;
+  const chosenModel = typeof model === 'string' && model.trim() ? model.trim() : 'gpt-3.5-turbo';
+  try {
+    const upstream = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: chosenModel,
+        messages,
+        stream: true,
+      }),
+    });
+    if (!upstream.ok) {
+      const errText = await upstream.text();
+      throw new Error(errText);
+    }
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    });
+    upstream.body.on('data', (chunk) => {
+      res.write(chunk);
+    });
+    upstream.body.on('end', () => {
+      res.end();
+    });
+    upstream.body.on('error', (err) => {
+      console.error('Stream error', err);
+      res.end();
+    });
+  } catch (err) {
+    res.status(500).end('Error: ' + err.message);
+  }
+}

--- a/pages/chatgpt-stream.js
+++ b/pages/chatgpt-stream.js
@@ -1,0 +1,113 @@
+import { useState, useRef, useEffect } from 'react';
+import Head from 'next/head';
+import ChatBubble from '@/components/ChatBubble';
+import DarkModeToggle from '@/components/DarkModeToggle';
+
+export default function ChatGptStreamPage() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef(null);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+    let botMsg = { role: 'assistant', text: '' };
+    setMessages((prev) => [...prev, botMsg]);
+    try {
+      const res = await fetch('/api/chatgpt-stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text })),
+        }),
+      });
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value);
+        const lines = chunk.split('\n');
+        for (const line of lines) {
+          const cleaned = line.replace(/^data: /, '').trim();
+          if (!cleaned || cleaned === '[DONE]') continue;
+          try {
+            const data = JSON.parse(cleaned);
+            const content = data.choices?.[0]?.delta?.content;
+            if (content) {
+              botMsg.text += content;
+              setMessages((prev) => {
+                const newMsgs = [...prev];
+                newMsgs[newMsgs.length - 1] = { ...botMsg };
+                return newMsgs;
+              });
+            }
+          } catch (err) {
+            console.error('Parse error', err);
+          }
+        }
+      }
+    } catch (err) {
+      setMessages((prev) => [...prev, { role: 'assistant', text: 'Error: ' + err.message }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>ChatGPT Stream UI</title>
+      </Head>
+      <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+          <DarkModeToggle />
+        </div>
+        <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
+          {messages.map((msg, idx) => (
+            <ChatBubble key={idx} message={msg} />
+          ))}
+          {loading && <ChatBubble message={{ role: 'assistant', text: '...' }} />}
+          <div ref={endRef} />
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
+          <textarea
+            ref={inputRef}
+            rows={1}
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Send a message"
+          />
+          <button type="submit" className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50" disabled={loading} aria-label="Send message">
+            Send
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/api/chatgpt-stream` for streaming ChatGPT responses
- add new `/chatgpt-stream` page using the streaming API
- document new files in README

## Testing
- `node validate.js`

------
https://chatgpt.com/codex/tasks/task_e_6858aa1351ac83289249c44fd3a0cd80