### PR TITLE
Add ChatGPT UI quick start guide

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -1,0 +1,27 @@
+# ChatGPT UI Quick Start
+
+This repository includes a simple ChatGPT interface built with Next.js and the OpenAI API. Follow these steps to run it locally:
+
+1. Install dependencies if needed:
+
+```bash
+npm install
+```
+
+2. Set the `OPENAI_API_KEY` environment variable to your OpenAI API key.
+3. Start the development server:
+
+```bash
+npm run dev
+```
+
+4. Open `http://localhost:3000/` in your browser.
+
+Other pages to explore:
+
+- `/chatgpt` – same interface as the home page.
+- `/gpt` – select a different model.
+- `/chatgpt-ui` – messages persist across reloads.
+- `/chatgpt-ko` – Korean interface.
+
+All chat pages include a **Dark Mode** toggle.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
 For conversations that persist across page reloads, visit `/chatgpt-ui`.
 A Korean interface is available at `/chatgpt-ko`.
 All chat pages now include a **Dark Mode** toggle in the header.
+For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 
 Key files implementing the chat interface:
 


### PR DESCRIPTION
## Summary
- add a standalone `CHATGPT_UI.md` with steps to run the ChatGPT interface
- reference this quick-start doc from the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a0ab1caf483289631f1e48bf2b1ea