### PR TITLE
Add clear chat button

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -24,4 +24,4 @@ Other pages to explore:
 - `/chatgpt-ui` – messages persist across reloads.
 - `/chatgpt-ko` – Korean interface.
 
-All chat pages include a **Dark Mode** toggle.
+All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
 For conversations that persist across page reloads, visit `/chatgpt-ui`.
 A Korean interface is available at `/chatgpt-ko`.
 All chat pages now include a **Dark Mode** toggle in the header.
+You can also reset the conversation anytime using the new **Clear** button.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 
 Key files implementing the chat interface:

--- a/components/ClearChatButton.js
+++ b/components/ClearChatButton.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function ClearChatButton({ onClear, label = 'Clear' }) {
+  return (
+    <button
+      onClick={onClear}
+      className="border px-2 py-1 rounded text-sm bg-white dark:bg-gray-700 dark:text-gray-100"
+      aria-label={label}
+    >
+      {label}
+    </button>
+  );
+}

--- a/pages/chatgpt-ko.js
+++ b/pages/chatgpt-ko.js
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import ChatBubble from '@/components/ChatBubbleKo';
 import DarkModeToggle from '@/components/DarkModeToggle';
+import ClearChatButton from '@/components/ClearChatButton';
 
 const STORAGE_KEY = 'chatgptMessages';
 
@@ -11,6 +12,15 @@ export default function ChatGptKoPage() {
   const [loading, setLoading] = useState(false);
   const endRef = useRef(null);
   const inputRef = useRef(null);
+
+  const handleClear = () => {
+    setMessages([]);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (err) {
+      // ignore
+    }
+  };
 
   // Load messages from local storage on mount
   useEffect(() => {
@@ -83,8 +93,9 @@ export default function ChatGptKoPage() {
         <title>ChatGPT UI (한국어)</title>
       </Head>
       <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
           <DarkModeToggle />
+          <ClearChatButton onClear={handleClear} label="초기화" />
         </div>
         <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
           {messages.map((msg, idx) => (

--- a/pages/chatgpt-stream.js
+++ b/pages/chatgpt-stream.js
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import ChatBubble from '@/components/ChatBubble';
 import DarkModeToggle from '@/components/DarkModeToggle';
+import ClearChatButton from '@/components/ClearChatButton';
 
 export default function ChatGptStreamPage() {
   const [messages, setMessages] = useState([]);
@@ -9,6 +10,11 @@ export default function ChatGptStreamPage() {
   const [loading, setLoading] = useState(false);
   const endRef = useRef(null);
   const inputRef = useRef(null);
+
+  const handleClear = () => {
+    setMessages([]);
+    setLoading(false);
+  };
 
   useEffect(() => {
     if (endRef.current) {
@@ -84,8 +90,9 @@ export default function ChatGptStreamPage() {
         <title>ChatGPT Stream UI</title>
       </Head>
       <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
           <DarkModeToggle />
+          <ClearChatButton onClear={handleClear} />
         </div>
         <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
           {messages.map((msg, idx) => (

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import ChatBubble from '@/components/ChatBubble';
 import DarkModeToggle from '@/components/DarkModeToggle';
+import ClearChatButton from '@/components/ClearChatButton';
 
 const STORAGE_KEY = 'chatgptMessages';
 
@@ -11,6 +12,15 @@ export default function ChatGptUIPersist() {
   const [loading, setLoading] = useState(false);
   const endRef = useRef(null);
   const inputRef = useRef(null);
+
+  const handleClear = () => {
+    setMessages([]);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (err) {
+      // ignore
+    }
+  };
 
   // Load messages from local storage on mount
   useEffect(() => {
@@ -83,8 +93,9 @@ export default function ChatGptUIPersist() {
         <title>ChatGPT UI (Persistent)</title>
       </Head>
       <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
           <DarkModeToggle />
+          <ClearChatButton onClear={handleClear} />
         </div>
         <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
           {messages.map((msg, idx) => (

--- a/pages/chatgpt.js
+++ b/pages/chatgpt.js
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import ChatBubble from '@/components/ChatBubble';
 import DarkModeToggle from '@/components/DarkModeToggle';
+import ClearChatButton from '@/components/ClearChatButton';
 
 export default function ChatGptPage() {
   const [messages, setMessages] = useState([]);
@@ -9,6 +10,10 @@ export default function ChatGptPage() {
   const [loading, setLoading] = useState(false);
   const endRef = useRef(null);
   const inputRef = useRef(null);
+
+  const handleClear = () => {
+    setMessages([]);
+  };
 
   useEffect(() => {
     if (endRef.current) {
@@ -60,8 +65,9 @@ export default function ChatGptPage() {
         <title>ChatGPT UI</title>
       </Head>
       <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
           <DarkModeToggle />
+          <ClearChatButton onClear={handleClear} />
         </div>
         <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
           {messages.map((msg, idx) => (

--- a/pages/gpt.js
+++ b/pages/gpt.js
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import ChatBubble from '@/components/ChatBubble';
 import DarkModeToggle from '@/components/DarkModeToggle';
+import ClearChatButton from '@/components/ClearChatButton';
 
 const MODELS = ['gpt-3.5-turbo', 'gpt-4'];
 
@@ -12,6 +13,10 @@ export default function GptUIPage() {
   const [loading, setLoading] = useState(false);
   const endRef = useRef(null);
   const inputRef = useRef(null);
+
+  const handleClear = () => {
+    setMessages([]);
+  };
 
   useEffect(() => {
     if (endRef.current) {
@@ -64,8 +69,9 @@ export default function GptUIPage() {
         <title>GPT UI</title>
       </Head>
       <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
           <DarkModeToggle />
+          <ClearChatButton onClear={handleClear} />
         </div>
         <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
           {messages.map((msg, idx) => (


### PR DESCRIPTION
## Summary
- add reusable `ClearChatButton` component
- include button on all ChatGPT UI pages
- document the new clear option in README and quick start guide

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f564c79d48328a9fe4ed9ae5dc6cb