### PR TITLE
Update README for quick ChatGPT UI start

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ can also access it directly via `/chatgpt`.
 To run it locally:
 
 1. Set the `OPENAI_API_KEY` environment variable.
+   You can also run the server inline with the key:
+   ```bash
+   OPENAI_API_KEY=your-key npm run dev
+   ```
 2. Start the dev server:
 
    ```bash


### PR DESCRIPTION
## Summary
- clarify how to run the ChatGPT UI with an inline `OPENAI_API_KEY`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c6aed0cc8328bf2c1d9ab5417505