### PR TITLE
Add Korean quick-start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A Korean interface is available at `/chatgpt-ko`.
 All chat pages now include a **Dark Mode** toggle in the header.
 You can also reset the conversation anytime using the new **Clear** button.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
+Korean instructions are available in [README_KO.md](./README_KO.md).
 
 Key files implementing the chat interface:
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,0 +1,26 @@
+# 티타늄 도마 사이트
+
+이 저장소에는 Next.js와 OpenAI API로 만든 간단한 ChatGPT 인터페이스가 포함되어 있습니다. 홈 페이지(`/`)에서 바로 사용하거나 `/chatgpt` 경로로 접속할 수 있습니다.
+
+## 로컬 실행 방법
+
+1. 의존성 설치:
+   ```bash
+   npm install
+   ```
+2. `OPENAI_API_KEY` 환경 변수를 설정한 후 개발 서버를 실행합니다:
+   ```bash
+   npm run dev
+   ```
+   또는 다음처럼 한 줄로 실행할 수 있습니다:
+   ```bash
+   OPENAI_API_KEY=your-key npm run dev
+   ```
+3. 브라우저에서 `http://localhost:3000` 을 열어 대화를 시작합니다.
+
+추가 페이지:
+- `/gpt` : 다른 모델 선택
+- `/chatgpt-ui` : 대화 내용이 저장되는 버전
+- `/chatgpt-ko` : 한국어 인터페이스
+
+어두운 테마(Dark Mode)와 대화 초기화(Clear) 버튼도 제공합니다.


### PR DESCRIPTION
## Summary
- add `README_KO.md` with Korean instructions for running the ChatGPT UI
- reference the new file in `README.md`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68649d0ac5c48328bee1deacc3d8a420