### PR TITLE
Add OPENAI_MODEL support

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -8,7 +8,8 @@ This repository includes a simple ChatGPT interface built with Next.js and the O
 npm install
 ```
 
-2. Set the `OPENAI_API_KEY` environment variable to your OpenAI API key and start the development server:
+2. Set the `OPENAI_API_KEY` environment variable to your OpenAI API key.
+   Optionally set `OPENAI_MODEL` to choose a different default model, then start the development server:
 
 ```bash
 npm run dev
@@ -17,7 +18,7 @@ npm run dev
    You can also run the server inline with the key:
 
 ```bash
-OPENAI_API_KEY=your-key npm run dev
+OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 npm run dev
 ```
 
 3. Open `http://localhost:3000/` in your browser.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ can also access it directly via `/chatgpt`.
 To run it locally:
 
 1. Set the `OPENAI_API_KEY` environment variable.
+   Optionally specify `OPENAI_MODEL` to change the default model.
    You can also run the server inline with the key:
    ```bash
-   OPENAI_API_KEY=your-key npm run dev
+   OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 npm run dev
    ```
 2. Start the dev server:
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -8,13 +8,14 @@
    ```bash
    npm install
    ```
-2. `OPENAI_API_KEY` 환경 변수를 설정한 후 개발 서버를 실행합니다:
+2. `OPENAI_API_KEY` 환경 변수를 설정하고,
+   기본 모델을 변경하려면 `OPENAI_MODEL` 도 지정한 후 개발 서버를 실행합니다:
    ```bash
    npm run dev
    ```
    또는 다음처럼 한 줄로 실행할 수 있습니다:
    ```bash
-   OPENAI_API_KEY=your-key npm run dev
+   OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 npm run dev
    ```
 3. 브라우저에서 `http://localhost:3000` 을 열어 대화를 시작합니다.
 

--- a/pages/api/chatgpt-stream.js
+++ b/pages/api/chatgpt-stream.js
@@ -9,7 +9,10 @@ export default async function handler(req, res) {
     return;
   }
   const { messages, model } = req.body;
-  const chosenModel = typeof model === 'string' && model.trim() ? model.trim() : 'gpt-3.5-turbo';
+  const defaultModel = process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
+  const chosenModel = typeof model === 'string' && model.trim()
+    ? model.trim()
+    : defaultModel;
   try {
     const upstream = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',

--- a/pages/api/chatgpt.js
+++ b/pages/api/chatgpt.js
@@ -9,7 +9,10 @@ export default async function handler(req, res) {
     return;
   }
   const { messages, model } = req.body;
-  const chosenModel = typeof model === 'string' && model.trim() ? model.trim() : 'gpt-3.5-turbo';
+  const defaultModel = process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
+  const chosenModel = typeof model === 'string' && model.trim()
+    ? model.trim()
+    : defaultModel;
   try {
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- allow setting a default OpenAI model via `OPENAI_MODEL`
- document the new variable in README
- update the Korean README and quick start guide

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68685dc8fe68832886e829fd0a2607e8