### PR TITLE
Add Enter key chat submission

### DIFF
--- a/pages/chat.js
+++ b/pages/chat.js
@@ -17,6 +17,13 @@ export default function ChatPage() {
     setInput('');
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
   return (
     <>
       <Head>
@@ -34,6 +41,7 @@ export default function ChatPage() {
             className="w-full border border-gray-300 rounded p-2 resize-none"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="Send a message"
           />
           <button type="submit" className="bg-blue-500 text-white rounded px-4 py-2">

--- a/pages/chatgpt-ko.js
+++ b/pages/chatgpt-ko.js
@@ -87,6 +87,13 @@ export default function ChatGptKoPage() {
     }
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
   return (
     <>
       <Head>
@@ -113,6 +120,7 @@ export default function ChatGptKoPage() {
             className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="메시지를 입력하세요"
           />
           <button

--- a/pages/chatgpt-stream.js
+++ b/pages/chatgpt-stream.js
@@ -84,6 +84,13 @@ export default function ChatGptStreamPage() {
     }
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
   return (
     <>
       <Head>
@@ -108,6 +115,7 @@ export default function ChatGptStreamPage() {
             className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="Send a message"
           />
           <button type="submit" className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50" disabled={loading} aria-label="Send message">

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -87,6 +87,13 @@ export default function ChatGptUIPersist() {
     }
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
   return (
     <>
       <Head>
@@ -113,6 +120,7 @@ export default function ChatGptUIPersist() {
             className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="Send a message"
           />
           <button

--- a/pages/chatgpt.js
+++ b/pages/chatgpt.js
@@ -59,6 +59,13 @@ export default function ChatGptPage() {
     }
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
   return (
     <>
       <Head>
@@ -85,6 +92,7 @@ export default function ChatGptPage() {
             className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="Send a message"
           />
           <button

--- a/pages/chatui.js
+++ b/pages/chatui.js
@@ -17,6 +17,13 @@ export default function ChatUI() {
     setInput('');
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
   return (
     <>
       <Head>
@@ -34,6 +41,7 @@ export default function ChatUI() {
             className="w-full border border-gray-300 rounded p-2 resize-none"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="Send a message"
           />
           <button type="submit" className="bg-blue-500 text-white rounded px-4 py-2">

--- a/pages/gpt.js
+++ b/pages/gpt.js
@@ -63,6 +63,13 @@ export default function GptUIPage() {
     }
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
   return (
     <>
       <Head>
@@ -98,6 +105,7 @@ export default function GptUIPage() {
             className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="Send a message"
           />
           <button


### PR DESCRIPTION
## Summary
- allow submitting chat messages by pressing <kbd>Enter</kbd> (shift+enter for newline)

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706e7a09248328ac9bb343fbb90dd7