### PR TITLE
Improve dark mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ To run it locally:
 You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
 For conversations that persist across page reloads, visit `/chatgpt-ui`.
 A Korean interface is available at `/chatgpt-ko`.
-All chat pages now include a **Dark Mode** toggle in the header.
+All chat pages now include a **Dark Mode** toggle in the header. If you haven't
+set a preference, the toggle follows your system's color scheme by default.
 You can also reset the conversation anytime using the new **Clear** button.
 An **Export** button copies the current conversation to your clipboard.
 There's also a **Download** button to save the conversation as a text file.

--- a/components/DarkModeToggle.js
+++ b/components/DarkModeToggle.js
@@ -3,11 +3,16 @@ import { useEffect, useState } from 'react';
 export default function DarkModeToggle() {
   const [enabled, setEnabled] = useState(false);
 
-  // load saved setting
+  // load saved setting or system preference
   useEffect(() => {
     try {
       const saved = localStorage.getItem('darkMode');
-      if (saved === 'true') {
+      if (saved === 'true' || saved === 'false') {
+        setEnabled(saved === 'true');
+        if (saved === 'true') {
+          document.documentElement.classList.add('dark');
+        }
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
         setEnabled(true);
         document.documentElement.classList.add('dark');
       }


### PR DESCRIPTION
## Summary
- default dark mode to system preference when no saved setting
- note the behavior in the README

## Testing
- `node validate.js`
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden due to missing internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6874f74e0b848328986be84cd45a1239