### PR TITLE
Add system prompt option for ChatGPT UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@
 OPENAI_API_KEY=
 # Optional: override default model
 # OPENAI_MODEL=gpt-4
+# Optional: add a custom system message sent with every request
+# OPENAI_SYSTEM_MESSAGE="You are a helpful assistant."

--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -9,7 +9,8 @@ npm install
 ```
 
 2. Set the `OPENAI_API_KEY` environment variable to your OpenAI API key.
-   Optionally set `OPENAI_MODEL` to choose a different default model, then start the development server:
+   Optionally set `OPENAI_MODEL` to choose a different default model and
+   `OPENAI_SYSTEM_MESSAGE` for a custom system prompt, then start the development server:
 
 ```bash
 npm run dev
@@ -18,7 +19,8 @@ npm run dev
    You can also run the server inline with the key:
 
 ```bash
-OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 npm run dev
+OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 \
+OPENAI_SYSTEM_MESSAGE="You are a helpful assistant." npm run dev
 ```
 
 3. Open `http://localhost:3000/` in your browser.

--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ To run it locally:
 
 1. Set the required `OPENAI_API_KEY` environment variable. You can copy
    `.env.example` to `.env.local` and add your key there. Optionally
-   specify `OPENAI_MODEL` to change the default model. You can also run
+   specify `OPENAI_MODEL` to change the default model and
+   `OPENAI_SYSTEM_MESSAGE` to include a custom system prompt. You can also run
    the server inline with the key:
    ```bash
-   OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 npm run dev
+   OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 \
+   OPENAI_SYSTEM_MESSAGE="You are a helpful assistant." npm run dev
    ```
 2. Start the dev server:
 

--- a/pages/api/chatgpt-stream.js
+++ b/pages/api/chatgpt-stream.js
@@ -13,6 +13,10 @@ export default async function handler(req, res) {
   const chosenModel = typeof model === 'string' && model.trim()
     ? model.trim()
     : defaultModel;
+  const systemPrompt = process.env.OPENAI_SYSTEM_MESSAGE;
+  const allMessages = systemPrompt
+    ? [{ role: 'system', content: systemPrompt }, ...messages]
+    : messages;
   try {
     const upstream = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -22,7 +26,7 @@ export default async function handler(req, res) {
       },
       body: JSON.stringify({
         model: chosenModel,
-        messages,
+        messages: allMessages,
         stream: true,
       }),
     });

--- a/pages/api/chatgpt.js
+++ b/pages/api/chatgpt.js
@@ -13,6 +13,10 @@ export default async function handler(req, res) {
   const chosenModel = typeof model === 'string' && model.trim()
     ? model.trim()
     : defaultModel;
+  const systemPrompt = process.env.OPENAI_SYSTEM_MESSAGE;
+  const allMessages = systemPrompt
+    ? [{ role: 'system', content: systemPrompt }, ...messages]
+    : messages;
   try {
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -22,7 +26,7 @@ export default async function handler(req, res) {
       },
       body: JSON.stringify({
         model: chosenModel,
-        messages,
+        messages: allMessages,
       }),
     });
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- allow specifying `OPENAI_SYSTEM_MESSAGE` for ChatGPT API routes
- document the new environment variable in README and CHATGPT_UI.md
- update `.env.example` with example system message

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a76cce8fc8328981a6014227b4833