### PR TITLE
Add advanced ChatGPT UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -29,6 +29,7 @@ Other pages to explore:
 
 - `/chatgpt` – same interface as the home page.
 - `/gpt` – select a different model.
+- `/chatgpt-advanced` – set a custom system prompt.
 - `/chatgpt-ui` – messages persist across reloads.
 - `/chatgpt-ui-stream` – streaming replies with persistent history.
 - `/chatgpt-ko` – Korean interface.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ To run it locally:
 3. Open `http://localhost:3000` in your browser.
 
 You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
+An advanced page at `/chatgpt-advanced` lets you set a custom system prompt.
 For conversations that persist across page reloads, visit `/chatgpt-ui`.
 A streaming version with persistence is available at `/chatgpt-ui-stream`.
 A Korean interface is available at `/chatgpt-ko`.
@@ -101,6 +102,7 @@ Key files implementing the chat interface:
 - `pages/chatgpt-ko.js` – Korean language interface.
 - `pages/chatgpt-stream.js` – streams responses token by token.
 - `pages/chatgpt-ui-stream.js` – combines streaming replies with persistent messages.
+- `pages/chatgpt-advanced.js` – choose a model and system prompt.
 - `pages/api/chatgpt-stream.js` – API route powering the streaming UI.
 
 Below is a short excerpt from the `handleSubmit` function in

--- a/pages/api/chatgpt-stream.js
+++ b/pages/api/chatgpt-stream.js
@@ -8,14 +8,18 @@ export default async function handler(req, res) {
     res.status(500).end('Missing OPENAI_API_KEY');
     return;
   }
-  const { messages, model } = req.body;
+  const { messages, model, systemPrompt } = req.body;
   const defaultModel = process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
   const chosenModel = typeof model === 'string' && model.trim()
     ? model.trim()
     : defaultModel;
-  const systemPrompt = process.env.OPENAI_SYSTEM_MESSAGE;
-  const allMessages = systemPrompt
-    ? [{ role: 'system', content: systemPrompt }, ...messages]
+  const envPrompt = process.env.OPENAI_SYSTEM_MESSAGE;
+  const finalPrompt =
+    typeof systemPrompt === 'string' && systemPrompt.trim()
+      ? systemPrompt.trim()
+      : envPrompt;
+  const allMessages = finalPrompt
+    ? [{ role: 'system', content: finalPrompt }, ...messages]
     : messages;
   try {
     const upstream = await fetch('https://api.openai.com/v1/chat/completions', {

--- a/pages/api/chatgpt.js
+++ b/pages/api/chatgpt.js
@@ -8,14 +8,18 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Missing OPENAI_API_KEY' });
     return;
   }
-  const { messages, model } = req.body;
+  const { messages, model, systemPrompt } = req.body;
   const defaultModel = process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
   const chosenModel = typeof model === 'string' && model.trim()
     ? model.trim()
     : defaultModel;
-  const systemPrompt = process.env.OPENAI_SYSTEM_MESSAGE;
-  const allMessages = systemPrompt
-    ? [{ role: 'system', content: systemPrompt }, ...messages]
+  const envPrompt = process.env.OPENAI_SYSTEM_MESSAGE;
+  const finalPrompt =
+    typeof systemPrompt === 'string' && systemPrompt.trim()
+      ? systemPrompt.trim()
+      : envPrompt;
+  const allMessages = finalPrompt
+    ? [{ role: 'system', content: finalPrompt }, ...messages]
     : messages;
   try {
     const response = await fetch('https://api.openai.com/v1/chat/completions', {

--- a/pages/chatgpt-advanced.js
+++ b/pages/chatgpt-advanced.js
@@ -1,0 +1,134 @@
+import { useState, useRef, useEffect } from 'react';
+import Head from 'next/head';
+import ChatBubble from '@/components/ChatBubble';
+import DarkModeToggle from '@/components/DarkModeToggle';
+import ClearChatButton from '@/components/ClearChatButton';
+import ExportChatButton from '@/components/ExportChatButton';
+
+const MODELS = ['gpt-3.5-turbo', 'gpt-4'];
+
+export default function ChatGptAdvanced() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [model, setModel] = useState(MODELS[0]);
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef(null);
+  const inputRef = useRef(null);
+
+  const handleClear = () => {
+    setMessages([]);
+  };
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input, time: new Date().toLocaleTimeString() };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model,
+          systemPrompt,
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text }))
+        }),
+      });
+      const data = await res.json();
+      const botMsg = { role: 'assistant', text: data.text || 'No response', time: new Date().toLocaleTimeString() };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      const errorMsg = { role: 'assistant', text: 'Error: ' + err.message, time: new Date().toLocaleTimeString() };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>ChatGPT Advanced UI</title>
+      </Head>
+      <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2 items-start">
+          <DarkModeToggle />
+          <ClearChatButton onClear={handleClear} />
+          <ExportChatButton messages={messages} />
+        </div>
+        <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
+          {messages.map((msg, idx) => (
+            <ChatBubble key={idx} message={msg} />
+          ))}
+          {loading && (
+            <ChatBubble message={{ role: 'assistant', text: 'Loading...' }} />
+          )}
+          <div ref={endRef} />
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2 items-start">
+          <select
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            className="border border-gray-300 dark:border-gray-700 rounded p-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+          >
+            {MODELS.map((m) => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={systemPrompt}
+            onChange={(e) => setSystemPrompt(e.target.value)}
+            placeholder="System prompt"
+            className="border border-gray-300 dark:border-gray-700 rounded p-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 w-48"
+          />
+          <textarea
+            ref={inputRef}
+            rows={1}
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Send a message"
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50"
+            disabled={loading}
+            aria-label="Send message"
+          >
+            Send
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `/chatgpt-advanced` page that allows model and system prompt selection
- allow API routes to accept a `systemPrompt` field
- document the new page in README and CHATGPT_UI quick start

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d442e8b6483289ec63da922e95735