### PR TITLE
Add minimal ChatGPT UI page

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -28,6 +28,7 @@ OPENAI_SYSTEM_MESSAGE="You are a helpful assistant." npm run dev
 Other pages to explore:
 
 - `/chatgpt` – same interface as the home page.
+- `/chatgpt-simple` – minimal interface without dark mode or extras.
 - `/gpt` – select a different model.
 - `/chatgpt-advanced` – set a custom system prompt.
 - `/chatgpt-ui` – messages persist across reloads.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ To run it locally:
 3. Open `http://localhost:3000` in your browser.
 
 You can also choose a different model (e.g. `gpt-4`) at `/gpt`.
+A minimalist version is available at `/chatgpt-simple`.
 An advanced page at `/chatgpt-advanced` lets you set a custom system prompt.
 For conversations that persist across page reloads, visit `/chatgpt-ui`.
 A streaming version with persistence is available at `/chatgpt-ui-stream`.
@@ -96,6 +97,7 @@ Korean instructions are available in [README_KO.md](./README_KO.md).
 Key files implementing the chat interface:
 
 - `pages/chatgpt.js` – renders the chat UI.
+- `pages/chatgpt-simple.js` – minimal ChatGPT interface.
 - `pages/api/chatgpt.js` – API route that sends prompts to OpenAI.
 - `components/ChatBubble.js` – the message bubble component.
 - `pages/gpt.js` – variant with a model selector.

--- a/pages/chatgpt-simple.js
+++ b/pages/chatgpt-simple.js
@@ -1,0 +1,107 @@
+import { useState, useRef, useEffect } from 'react';
+import Head from 'next/head';
+import ChatBubble from '@/components/ChatBubble';
+// Minimal interface without extras
+
+export default function ChatGptPage() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef(null);
+  const inputRef = useRef(null);
+  const disableSend = loading || !input.trim();
+
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input, time: new Date().toLocaleTimeString() };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text }))
+        }),
+      });
+      const data = await res.json();
+      const botMsg = { role: 'assistant', text: data.text || 'No response', time: new Date().toLocaleTimeString() };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      const errorMsg = {
+        role: 'assistant',
+        text: 'Error: ' + err.message,
+        time: new Date().toLocaleTimeString(),
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>ChatGPT UI</title>
+      </Head>
+      <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
+          {messages.map((msg, idx) => (
+            <ChatBubble key={idx} message={msg} />
+          ))}
+          {loading && (
+            <ChatBubble message={{ role: 'assistant', text: 'Loading...' }} />
+          )}
+          <div ref={endRef} />
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
+          <textarea
+            ref={inputRef}
+            rows={1}
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Send a message"
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50"
+            disabled={disableSend}
+            aria-label="Send message"
+          >
+            Send
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create a simplified ChatGPT UI at `/chatgpt-simple`
- document new page in README and CHATGPT_UI.md

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688189f2909c8328b90d8b87c2ad19e2