### PR TITLE
Add markdown-enabled chat page

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -34,6 +34,7 @@ Other pages to explore:
 - `/chatgpt-ui` – messages persist across reloads.
 - `/chatgpt-persistent` – simplified persistent interface.
 - `/chatgpt-ui-stream` – streaming replies with persistent history.
+- `/chatgpt-markdown` – renders replies using Markdown.
 - `/chatgpt-ko` – Korean interface.
 
 All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ An advanced page at `/chatgpt-advanced` lets you set a custom system prompt.
 A simplified persistent page is available at `/chatgpt-persistent`.
 For conversations that persist across page reloads, visit `/chatgpt-ui`.
 A streaming version with persistence is available at `/chatgpt-ui-stream`.
+A Markdown-enabled version is at `/chatgpt-markdown`.
 A Korean interface is available at `/chatgpt-ko`.
 All chat pages now include a **Dark Mode** toggle in the header. If you haven't
 set a preference, the toggle follows your system's color scheme by default.
@@ -103,12 +104,14 @@ Key files implementing the chat interface:
 - `pages/chatgpt-lite.js` – ultra-lightweight interface.
 - `pages/api/chatgpt.js` – API route that sends prompts to OpenAI.
 - `components/ChatBubble.js` – the message bubble component.
+- `components/ChatBubbleMarkdown.js` – bubble with Markdown support.
 - `pages/gpt.js` – variant with a model selector.
 - `pages/chatgpt-ui.js` – version that stores messages in local storage.
 - `pages/chatgpt-persistent.js` – simplified UI that also persists messages.
 - `pages/chatgpt-ko.js` – Korean language interface.
 - `pages/chatgpt-stream.js` – streams responses token by token.
 - `pages/chatgpt-ui-stream.js` – combines streaming replies with persistent messages.
+- `pages/chatgpt-markdown.js` – renders messages using Markdown.
 - `pages/chatgpt-advanced.js` – choose a model and system prompt.
 - `pages/api/chatgpt-stream.js` – API route powering the streaming UI.
 

--- a/components/ChatBubbleMarkdown.js
+++ b/components/ChatBubbleMarkdown.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+export default function ChatBubbleMarkdown({ message }) {
+  const isUser = message.role === 'user';
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(message.text);
+    } catch (err) {
+      // ignore errors
+    }
+  };
+
+  return (
+    <div className={isUser ? 'bg-white dark:bg-gray-900' : 'bg-gray-50 dark:bg-gray-800'}>
+      <div className={`max-w-2xl mx-auto py-3 flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+        <div className="space-y-1 max-w-full">
+          <span className="text-xs text-gray-500">
+            {isUser ? 'You' : 'Assistant'}
+            {message.time && <span className="ml-1 text-gray-400">{message.time}</span>}
+          </span>
+          <div className="flex items-start gap-2">
+            <div
+              className={`rounded-md px-4 py-2 border prose dark:prose-invert whitespace-pre-wrap ${
+                isUser
+                  ? 'bg-gray-100 text-gray-900 border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700'
+                  : 'bg-white text-gray-900 border-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600'
+              }`}
+            >
+              <ReactMarkdown>{message.text}</ReactMarkdown>
+            </div>
+            <button
+              onClick={handleCopy}
+              className="text-xs text-blue-500 hover:underline mt-1"
+              aria-label="Copy message"
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "next": "13.4.13",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-markdown": "8.0.7"
   },
   "devDependencies": {
     "autoprefixer": "10.4.14",

--- a/pages/chatgpt-markdown.js
+++ b/pages/chatgpt-markdown.js
@@ -1,0 +1,119 @@
+import { useState, useRef, useEffect } from 'react';
+import Head from 'next/head';
+import ChatBubbleMarkdown from '@/components/ChatBubbleMarkdown';
+import DarkModeToggle from '@/components/DarkModeToggle';
+import ClearChatButton from '@/components/ClearChatButton';
+import ExportChatButton from '@/components/ExportChatButton';
+import DownloadChatButton from '@/components/DownloadChatButton';
+
+export default function ChatGptMarkdown() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef(null);
+  const inputRef = useRef(null);
+  const disableSend = loading || !input.trim();
+
+  const handleClear = () => {
+    setMessages([]);
+  };
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input, time: new Date().toLocaleTimeString() };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text })),
+        }),
+      });
+      const data = await res.json();
+      const botMsg = { role: 'assistant', text: data.text || 'No response', time: new Date().toLocaleTimeString() };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      const errorMsg = {
+        role: 'assistant',
+        text: 'Error: ' + err.message,
+        time: new Date().toLocaleTimeString(),
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>ChatGPT Markdown UI</title>
+      </Head>
+      <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
+          <DarkModeToggle />
+          <ClearChatButton onClear={handleClear} />
+          <ExportChatButton messages={messages} />
+          <DownloadChatButton messages={messages} />
+        </div>
+        <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
+          {messages.map((msg, idx) => (
+            <ChatBubbleMarkdown key={idx} message={msg} />
+          ))}
+          {loading && (
+            <ChatBubbleMarkdown message={{ role: 'assistant', text: 'Loading...' }} />
+          )}
+          <div ref={endRef} />
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
+          <textarea
+            ref={inputRef}
+            rows={1}
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Send a message"
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50"
+            disabled={disableSend}
+            aria-label="Send message"
+          >
+            Send
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `react-markdown` dependency
- support Markdown rendering in new `ChatBubbleMarkdown` component
- create `chatgpt-markdown` page that uses the new bubble
- document the Markdown page in README and CHATGPT_UI.md

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688965990fcc8328995d32c1ad2408cf