### PR TITLE
Add Cursor AI UI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ For conversations that persist across page reloads, visit `/chatgpt-ui`.
 A streaming version with persistence is available at `/chatgpt-ui-stream`.
 A Markdown-enabled version is at `/chatgpt-markdown`.
 A Korean interface is available at `/chatgpt-ko`.
+A Cursor-inspired interface is available at `/cursor-ai-ui`.
 All chat pages now include a **Dark Mode** toggle in the header. If you haven't
 set a preference, the toggle follows your system's color scheme by default.
 You can also reset the conversation anytime using the **Clear** button, which now asks for confirmation before deleting the chat.
@@ -109,6 +110,7 @@ Key files implementing the chat interface:
 - `pages/chatgpt-ui.js` – version that stores messages in local storage.
 - `pages/chatgpt-persistent.js` – simplified UI that also persists messages.
 - `pages/chatgpt-ko.js` – Korean language interface.
+- `pages/cursor-ai-ui.js` – Cursor AI interface with persistent messages.
 - `pages/chatgpt-stream.js` – streams responses token by token.
 - `pages/chatgpt-ui-stream.js` – combines streaming replies with persistent messages.
 - `pages/chatgpt-markdown.js` – renders messages using Markdown.

--- a/pages/cursor-ai-ui.js
+++ b/pages/cursor-ai-ui.js
@@ -1,0 +1,147 @@
+import { useState, useRef, useEffect } from 'react';
+import Head from 'next/head';
+import ChatBubble from '@/components/ChatBubble';
+import DarkModeToggle from '@/components/DarkModeToggle';
+import ClearChatButton from '@/components/ClearChatButton';
+import ExportChatButton from '@/components/ExportChatButton';
+import DownloadChatButton from '@/components/DownloadChatButton';
+
+const STORAGE_KEY = 'cursorAiMessages';
+
+export default function CursorAiUI() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef(null);
+  const inputRef = useRef(null);
+  const disableSend = loading || !input.trim();
+
+  const handleClear = () => {
+    setMessages([]);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (err) {
+      // ignore
+    }
+  };
+
+  // Load messages from local storage on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        setMessages(JSON.parse(saved));
+      }
+    } catch (err) {
+      console.error('Failed to load messages', err);
+    }
+  }, []);
+
+  // Save messages to local storage whenever they change
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+    } catch (err) {
+      console.error('Failed to save messages', err);
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', text: input, time: new Date().toLocaleTimeString() };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text }))
+        }),
+      });
+      const data = await res.json();
+      const botMsg = { role: 'assistant', text: data.text || 'No response', time: new Date().toLocaleTimeString() };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      const errorMsg = {
+        role: 'assistant',
+        text: 'Error: ' + err.message,
+        time: new Date().toLocaleTimeString(),
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Cursor AI UI</title>
+      </Head>
+      <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
+          <DarkModeToggle />
+          <ClearChatButton onClear={handleClear} />
+          <ExportChatButton messages={messages} />
+          <DownloadChatButton messages={messages} />
+        </div>
+        <div className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4">
+          {messages.map((msg, idx) => (
+            <ChatBubble key={idx} message={msg} />
+          ))}
+          {loading && (
+            <ChatBubble message={{ role: 'assistant', text: 'Loading...' }} />
+          )}
+          <div ref={endRef} />
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
+          <textarea
+            ref={inputRef}
+            rows={1}
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Send a message"
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50"
+            disabled={disableSend}
+            aria-label="Send message"
+          >
+            Send
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `cursor-ai-ui` page based on persistent ChatGPT UI
- document the new page in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a13fcdc1483289aaa9496c66bf15e