### PR TITLE
feat: recall last prompt with arrow key

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For conversations that persist across page reloads, visit `/chatgpt-ui`.
 A streaming version with persistence is available at `/chatgpt-ui-stream`.
 A Markdown-enabled version is at `/chatgpt-markdown`.
 A Korean interface is available at `/chatgpt-ko`.
-A Cursor-inspired interface is available at `/cursor-ai-ui`.
+A Cursor-inspired interface is available at `/cursor-ai-ui`, with persistent messages, auto-resizing input, and Up-arrow recall of your last prompt.
 All chat pages now include a **Dark Mode** toggle in the header. If you haven't
 set a preference, the toggle follows your system's color scheme by default.
 You can also reset the conversation anytime using the **Clear** button, which now asks for confirmation before deleting the chat.
@@ -110,7 +110,7 @@ Key files implementing the chat interface:
 - `pages/chatgpt-ui.js` – version that stores messages in local storage.
 - `pages/chatgpt-persistent.js` – simplified UI that also persists messages.
 - `pages/chatgpt-ko.js` – Korean language interface.
-- `pages/cursor-ai-ui.js` – Cursor AI interface with persistent messages.
+- `pages/cursor-ai-ui.js` – Cursor AI interface with persistent messages and Up-arrow recall.
 - `pages/chatgpt-stream.js` – streams responses token by token.
 - `pages/chatgpt-ui-stream.js` – combines streaming replies with persistent messages.
 - `pages/chatgpt-markdown.js` – renders messages using Markdown.

--- a/pages/cursor-ai-ui.js
+++ b/pages/cursor-ai-ui.js
@@ -104,7 +104,12 @@ export default function CursorAiUI() {
   };
 
   const handleKeyDown = (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'ArrowUp' && !input.trim()) {
+      const lastUser = [...messages].reverse().find((m) => m.role === 'user');
+      if (lastUser) {
+        setInput(lastUser.text);
+      }
+    } else if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(e);
     }


### PR DESCRIPTION
## Summary
- enable pressing Up in an empty input to recall the last user message in Cursor AI UI
- document Cursor-inspired UI features like auto-resizing input and Up-arrow recall

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e8ea2ddcc83289cf51303ab1a929a