### PR TITLE
feat: auto-resize chat input

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -41,3 +41,4 @@ All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start
 A new **Export** button lets you copy the chat history to your clipboard.
 You can also save the chat as a text file using the **Download** button.
 Each message now shows a timestamp for when it was sent.
+The message input automatically expands to fit longer content.

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -16,6 +16,14 @@ export default function ChatGptUIPersist() {
   const inputRef = useRef(null);
   const disableSend = loading || !input.trim();
 
+  const handleInputChange = (e) => {
+    setInput(e.target.value);
+    if (inputRef.current) {
+      inputRef.current.style.height = 'auto';
+      inputRef.current.style.height = `${inputRef.current.scrollHeight}px`;
+    }
+  };
+
   const handleClear = () => {
     setMessages([]);
     try {
@@ -70,6 +78,9 @@ export default function ChatGptUIPersist() {
     const userMsg = { role: 'user', text: input, time: new Date().toLocaleTimeString() };
     setMessages((prev) => [...prev, userMsg]);
     setInput('');
+    if (inputRef.current) {
+      inputRef.current.style.height = 'auto';
+    }
     setLoading(true);
     try {
       const res = await fetch('/api/chatgpt', {
@@ -126,9 +137,10 @@ export default function ChatGptUIPersist() {
           <textarea
             ref={inputRef}
             rows={1}
-            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            style={{ height: 'auto' }}
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none overflow-hidden bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
-            onChange={(e) => setInput(e.target.value)}
+            onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             placeholder="Send a message"
           />


### PR DESCRIPTION
## Summary
- auto-resize message textarea in ChatGPT UI
- document auto-expanding input in guide

## Testing
- `npm test` *(fails: Missing script: "test")*
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68914d1fffac8328b1be3f0e0673bbcd