### PR TITLE
Include timestamps in exported chats

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -38,7 +38,7 @@ Other pages to explore:
 - `/chatgpt-ko` – Korean interface.
 
 All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation.
-A new **Export** button lets you copy the chat history to your clipboard.
-You can also save the chat as a text file using the **Download** button.
+An **Export** button lets you copy the chat history—including timestamps—to your clipboard.
+You can also save the chat with timestamps as a text file using the **Download** button.
 Each message now shows a timestamp for when it was sent.
 The message input automatically expands to fit longer content.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ A Cursor-inspired interface is available at `/cursor-ai-ui`, with persistent mes
 All chat pages now include a **Dark Mode** toggle in the header. If you haven't
 set a preference, the toggle follows your system's color scheme by default.
 You can also reset the conversation anytime using the **Clear** button, which now asks for confirmation before deleting the chat.
-An **Export** button copies the current conversation to your clipboard.
-There's also a **Download** button to save the conversation as a text file.
+An **Export** button copies the current conversation—including timestamps—to your clipboard.
+There's also a **Download** button to save the conversation as a timestamped text file.
 Each message now has a small **Copy** button so you can quickly copy its text.
 The **Send** button stays disabled until you type a message or while waiting for a reply.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).

--- a/components/DownloadChatButton.js
+++ b/components/DownloadChatButton.js
@@ -2,7 +2,9 @@ import React from 'react';
 
 export default function DownloadChatButton({ messages, label = 'Download' }) {
   const handleDownload = () => {
-    const text = messages.map(m => `${m.role}: ${m.text}`).join('\n');
+    const text = messages
+      .map(m => `${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`)
+      .join('\n');
     const blob = new Blob([text], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/components/ExportChatButton.js
+++ b/components/ExportChatButton.js
@@ -2,7 +2,9 @@ import React from 'react';
 
 export default function ExportChatButton({ messages, label = 'Export' }) {
   const handleExport = async () => {
-    const text = messages.map(m => `${m.role}: ${m.text}`).join('\n');
+    const text = messages
+      .map(m => `${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`)
+      .join('\n');
     try {
       await navigator.clipboard.writeText(text);
       alert('Chat copied to clipboard');


### PR DESCRIPTION
## Summary
- Include message timestamps when exporting chat to clipboard
- Include message timestamps when downloading chat history
- Document timestamped export and download behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892aa142d488328b8daca9b3a7fee41