### PR TITLE
feat: show copy confirmation

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -41,5 +41,6 @@ All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start
 An **Export** button lets you copy the chat history—including timestamps—to your clipboard.
 You can also save the chat with timestamps as a text file using the **Download** button.
 Each message now shows a timestamp for when it was sent.
+Each message includes a **Copy** button that briefly displays "Copied!" after copying.
 The message input automatically expands to fit longer content.
 Press Shift+Enter to add a newline.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ set a preference, the toggle follows your system's color scheme by default.
 You can also reset the conversation anytime using the **Clear** button, which now asks for confirmation before deleting the chat.
 An **Export** button copies the current conversation—including timestamps—to your clipboard.
 There's also a **Download** button to save the conversation as a timestamped text file.
-Each message now has a small **Copy** button so you can quickly copy its text.
+Each message now has a small **Copy** button that briefly shows "Copied!" after you copy its text.
 The message input supports multi-line entries; press Shift+Enter for a new line.
 The **Send** button stays disabled until you type a message or while waiting for a reply.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).

--- a/components/ChatBubble.js
+++ b/components/ChatBubble.js
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function ChatBubble({ message }) {
   const isUser = message.role === 'user';
+  const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(message.text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       // ignore errors
     }
@@ -40,7 +43,7 @@ export default function ChatBubble({ message }) {
               className="text-xs text-blue-500 hover:underline mt-1"
               aria-label="Copy message"
             >
-              Copy
+              {copied ? 'Copied!' : 'Copy'}
             </button>
           </div>
         </div>

--- a/components/ChatBubbleMarkdown.js
+++ b/components/ChatBubbleMarkdown.js
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 export default function ChatBubbleMarkdown({ message }) {
   const isUser = message.role === 'user';
+  const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(message.text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       // ignore errors
     }
@@ -35,7 +38,7 @@ export default function ChatBubbleMarkdown({ message }) {
               className="text-xs text-blue-500 hover:underline mt-1"
               aria-label="Copy message"
             >
-              Copy
+              {copied ? 'Copied!' : 'Copy'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- show "Copied!" feedback when copying chat messages
- document copy confirmation in ChatGPT UI docs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898cb39da3883289adc8212803d96cd