### PR TITLE
feat: auto-resize input in streaming chat UI

### DIFF
--- a/pages/chatgpt-ui-stream.js
+++ b/pages/chatgpt-ui-stream.js
@@ -16,6 +16,14 @@ export default function ChatGptUIStream() {
   const inputRef = useRef(null);
   const disableSend = loading || !input.trim();
 
+  const handleInputChange = (e) => {
+    setInput(e.target.value);
+    if (inputRef.current) {
+      inputRef.current.style.height = 'auto';
+      inputRef.current.style.height = `${inputRef.current.scrollHeight}px`;
+    }
+  };
+
   const handleClear = () => {
     setMessages([]);
     try {
@@ -70,6 +78,9 @@ export default function ChatGptUIStream() {
     const userMsg = { role: 'user', text: input, time: new Date().toLocaleTimeString() };
     setMessages((prev) => [...prev, userMsg]);
     setInput('');
+    if (inputRef.current) {
+      inputRef.current.style.height = 'auto';
+    }
     setLoading(true);
     let botMsg = { role: 'assistant', text: '', time: new Date().toLocaleTimeString() };
     setMessages((prev) => [...prev, botMsg]);
@@ -147,9 +158,10 @@ export default function ChatGptUIStream() {
           <textarea
             ref={inputRef}
             rows={1}
-            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            style={{ height: 'auto' }}
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none overflow-hidden bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
-            onChange={(e) => setInput(e.target.value)}
+            onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             placeholder="Send a message (Shift+Enter for newline)"
           />


### PR DESCRIPTION
## Summary
- auto-expand chat input height in streaming UI for better multi-line editing
- reset input height after sending messages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a576e1dac8328a1ccfddc3e4a6886