### PR TITLE
feat: refocus input after clearing chat

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -37,7 +37,7 @@ Other pages to explore:
 - `/chatgpt-markdown` – renders replies using Markdown.
 - `/chatgpt-ko` – Korean interface.
 
-All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation.
+All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation; the message input refocuses automatically.
 An **Export** button lets you copy the chat history—including timestamps—to your clipboard.
 You can also save the chat with timestamps as a text file using the **Download** button.
 Each message now shows a timestamp for when it was sent.

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -31,6 +31,10 @@ export default function ChatGptUIPersist() {
     } catch (err) {
       // ignore
     }
+    if (inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.style.height = 'auto';
+    }
   };
 
   // Load messages from local storage on mount
@@ -143,6 +147,7 @@ export default function ChatGptUIPersist() {
             rows={1}
             style={{ height: 'auto' }}
             className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 resize-none overflow-hidden bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            aria-label="Message input"
             value={input}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Summary
- Refocus and reset input area whenever chat history is cleared for smoother flow
- Add accessibility label to the message input
- Document auto-refocus behavior in ChatGPT UI guide

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b4753c9348328ad12bf87fb1c7314