### PR TITLE
feat: connect chat ui to chatgpt api

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Korean instructions are available in [README_KO.md](./README_KO.md).
 Key files implementing the chat interface:
 
 - `pages/chatgpt.js` – renders the chat UI.
+- `pages/chatui.js` – stripped-down ChatGPT UI without dark mode or extras.
 - `pages/chatgpt-simple.js` – minimal ChatGPT interface.
 - `pages/chatgpt-lite.js` – ultra-lightweight interface.
 - `pages/api/chatgpt.js` – API route that sends prompts to OpenAI.

--- a/pages/chatui.js
+++ b/pages/chatui.js
@@ -1,21 +1,63 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import ChatBubble from '@/components/ChatBubble';
 
 export default function ChatUI() {
   const [messages, setMessages] = useState([
-    { role: 'assistant', text: 'Welcome! How can I help?', time: new Date().toLocaleTimeString() }
+    { role: 'assistant', text: 'Welcome! How can I help?', time: new Date().toLocaleTimeString() },
   ]);
   const [input, setInput] = useState('');
-  const disableSend = !input.trim();
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef(null);
+  const inputRef = useRef(null);
+  const disableSend = loading || !input.trim();
 
-  const handleSubmit = (e) => {
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, loading]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!loading && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [loading]);
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!input.trim()) return;
     const userMsg = { role: 'user', text: input, time: new Date().toLocaleTimeString() };
-    const botMsg = { role: 'assistant', text: `You said: ${input}`, time: new Date().toLocaleTimeString() };
-    setMessages((prev) => [...prev, userMsg, botMsg]);
+    setMessages((prev) => [...prev, userMsg]);
     setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chatgpt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [...messages, userMsg].map((m) => ({ role: m.role, content: m.text })),
+        }),
+      });
+      const data = await res.json();
+      const botMsg = { role: 'assistant', text: data.text || 'No response', time: new Date().toLocaleTimeString() };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      const errorMsg = {
+        role: 'assistant',
+        text: 'Error: ' + err.message,
+        time: new Date().toLocaleTimeString(),
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleKeyDown = (e) => {
@@ -31,13 +73,16 @@ export default function ChatUI() {
         <title>Chat UI</title>
       </Head>
       <div className="flex flex-col h-screen">
-        <div className="flex-1 overflow-y-auto bg-gray-100">
+        <div className="flex-1 overflow-y-auto bg-gray-100 p-4">
           {messages.map((m, idx) => (
             <ChatBubble key={idx} message={m} />
           ))}
+          {loading && <ChatBubble message={{ role: 'assistant', text: 'Loading...' }} />}
+          <div ref={endRef} />
         </div>
         <form onSubmit={handleSubmit} className="p-4 border-t bg-white flex gap-2">
           <textarea
+            ref={inputRef}
             rows={1}
             className="w-full border border-gray-300 rounded p-2 resize-none"
             value={input}
@@ -45,7 +90,11 @@ export default function ChatUI() {
             onKeyDown={handleKeyDown}
             placeholder="Send a message (Shift+Enter for newline)"
           />
-          <button type="submit" className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50" disabled={disableSend}>
+          <button
+            type="submit"
+            className="bg-blue-500 text-white rounded px-4 py-2 disabled:opacity-50"
+            disabled={disableSend}
+          >
             Send
           </button>
         </form>


### PR DESCRIPTION
## Summary
- hook the basic `chatui` page up to the ChatGPT API for real responses
- document the new stripped-down ChatGPT UI in the README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0d68f19b48328915f73e0744bab75