### PR TITLE
feat: add typing indicator to ChatGPT UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -44,3 +44,4 @@ Each message now shows a timestamp for when it was sent.
 Each message includes a **Copy** button that briefly displays "Copied!" after copying.
 The message input automatically expands to fit longer content.
 Press Shift+Enter to add a newline.
+An animated typing indicator appears while waiting for a response.

--- a/components/TypingIndicator.js
+++ b/components/TypingIndicator.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function TypingIndicator() {
+  return (
+    <div className="bg-gray-50 dark:bg-gray-800">
+      <div className="max-w-2xl mx-auto py-3 flex justify-start">
+        <div className="space-y-1 max-w-full">
+          <span className="text-xs text-gray-500">Assistant</span>
+          <div className="flex items-start gap-2">
+            <div className="rounded-md px-4 py-2 border bg-white text-gray-900 border-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600">
+              <div className="flex space-x-1">
+                <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"></span>
+                <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:0.2s]"></span>
+                <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:0.4s]"></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/chatgpt-ui-stream.js
+++ b/pages/chatgpt-ui-stream.js
@@ -5,6 +5,7 @@ import DarkModeToggle from '@/components/DarkModeToggle';
 import ClearChatButton from '@/components/ClearChatButton';
 import ExportChatButton from '@/components/ExportChatButton';
 import DownloadChatButton from '@/components/DownloadChatButton';
+import TypingIndicator from '@/components/TypingIndicator';
 
 const STORAGE_KEY = 'chatgptStreamMessages';
 
@@ -151,7 +152,7 @@ export default function ChatGptUIStream() {
           {messages.map((msg, idx) => (
             <ChatBubble key={idx} message={msg} />
           ))}
-          {loading && <ChatBubble message={{ role: 'assistant', text: '...' }} />}
+          {loading && <TypingIndicator />}
           <div ref={endRef} />
         </div>
         <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -5,6 +5,7 @@ import DarkModeToggle from '@/components/DarkModeToggle';
 import ClearChatButton from '@/components/ClearChatButton';
 import ExportChatButton from '@/components/ExportChatButton';
 import DownloadChatButton from '@/components/DownloadChatButton';
+import TypingIndicator from '@/components/TypingIndicator';
 
 const STORAGE_KEY = 'chatgptMessages';
 
@@ -136,9 +137,7 @@ export default function ChatGptUIPersist() {
           {messages.map((msg, idx) => (
             <ChatBubble key={idx} message={msg} />
           ))}
-          {loading && (
-            <ChatBubble message={{ role: 'assistant', text: 'Loading...' }} />
-          )}
+          {loading && <TypingIndicator />}
           <div ref={endRef} />
         </div>
         <form onSubmit={handleSubmit} className="p-4 border-t bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">


### PR DESCRIPTION
## Summary
- add animated typing indicator component
- show typing indicator while ChatGPT response loads
- document typing indicator in ChatGPT UI guide

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3c69457388328964fe04ed52e2e17