### PR TITLE
Render markdown in persistent ChatGPT UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -1,6 +1,6 @@
 # ChatGPT UI Quick Start
 
-This repository includes a ChatGPT UI with persistent conversations built with Next.js and the OpenAI API. The home page now defaults to this interface (also available at `/chatgpt-ui`). A basic non-persistent interface remains available at `/chatgpt`. Follow these steps to run it locally:
+This repository includes a ChatGPT UI with persistent conversations built with Next.js and the OpenAI API. The home page now defaults to this interface (also available at `/chatgpt-ui`) and renders replies using Markdown for formatted output. A basic non-persistent interface remains available at `/chatgpt`. Follow these steps to run it locally:
 
 1. Install dependencies if needed:
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Google Mobile Ads (`react-native-google-mobile-ads` @15.2.0) is integrated and a
 ## ChatGPT UI
 
 The site now defaults to the persistent ChatGPT UI on the home page (`/`).
+This interface renders replies using Markdown, so code blocks and formatting appear as expected.
 You can still access the simple, non-persistent interface at `/chatgpt`.
 
 To run it locally:

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
-import ChatBubble from '@/components/ChatBubble';
+import ChatBubbleMarkdown from '@/components/ChatBubbleMarkdown';
 import DarkModeToggle from '@/components/DarkModeToggle';
 import ClearChatButton from '@/components/ClearChatButton';
 import ExportChatButton from '@/components/ExportChatButton';
@@ -135,7 +135,7 @@ export default function ChatGptUIPersist() {
           aria-live="polite"
         >
           {messages.map((msg, idx) => (
-            <ChatBubble key={idx} message={msg} />
+            <ChatBubbleMarkdown key={idx} message={msg} />
           ))}
           {loading && <TypingIndicator />}
           <div ref={endRef} />


### PR DESCRIPTION
## Summary
- use Markdown chat bubbles in persistent ChatGPT UI
- document that home page renders Markdown responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a48ab62940832889a202b3b2639350