### PR TITLE
feat: support gfm in chatgpt ui

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -1,6 +1,6 @@
 # ChatGPT UI Quick Start
 
-This repository includes a ChatGPT UI with persistent conversations built with Next.js and the OpenAI API. The home page now defaults to this interface (also available at `/chatgpt-ui`) and renders replies using Markdown for formatted output. A basic non-persistent interface remains available at `/chatgpt`. Follow these steps to run it locally:
+This repository includes a ChatGPT UI with persistent conversations built with Next.js and the OpenAI API. The home page now defaults to this interface (also available at `/chatgpt-ui`) and renders replies using GitHub-flavored Markdown for formatted output. A basic non-persistent interface remains available at `/chatgpt`. Follow these steps to run it locally:
 
 1. Install dependencies if needed:
 
@@ -34,7 +34,7 @@ Other pages to explore:
 - `/chatgpt-ui` – same interface as the home page with persistent messages.
 - `/chatgpt-persistent` – simplified persistent interface.
 - `/chatgpt-ui-stream` – streaming replies with persistent history.
-- `/chatgpt-markdown` – renders replies using Markdown.
+- `/chatgpt-markdown` – renders replies using GitHub-flavored Markdown.
 - `/chatgpt-ko` – Korean interface.
 
 All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation; the message input refocuses automatically.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Google Mobile Ads (`react-native-google-mobile-ads` @15.2.0) is integrated and a
 ## ChatGPT UI
 
 The site now defaults to the persistent ChatGPT UI on the home page (`/`).
-This interface renders replies using Markdown, so code blocks and formatting appear as expected.
+This interface renders replies using GitHub-flavored Markdown, so code blocks, tables, and formatting appear as expected.
 You can still access the simple, non-persistent interface at `/chatgpt`.
 
 To run it locally:
@@ -86,7 +86,7 @@ An advanced page at `/chatgpt-advanced` lets you set a custom system prompt.
 A simplified persistent page is available at `/chatgpt-persistent`.
 The default persistent interface lives at `/chatgpt-ui`.
 A streaming version with persistence is available at `/chatgpt-ui-stream`.
-A Markdown-enabled version is at `/chatgpt-markdown`.
+A GitHub-flavored Markdown version is at `/chatgpt-markdown`.
 A Korean interface is available at `/chatgpt-ko`.
 A Cursor-inspired interface is available at `/cursor-ai-ui`, with persistent messages, auto-resizing input, and Up-arrow recall of your last prompt.
 All chat pages now include a **Dark Mode** toggle in the header. If you haven't
@@ -108,7 +108,7 @@ Key files implementing the chat interface:
 - `pages/chatgpt-lite.js` – ultra-lightweight interface.
 - `pages/api/chatgpt.js` – API route that sends prompts to OpenAI.
 - `components/ChatBubble.js` – the message bubble component.
-- `components/ChatBubbleMarkdown.js` – bubble with Markdown support.
+- `components/ChatBubbleMarkdown.js` – bubble with GitHub-flavored Markdown support.
 - `pages/gpt.js` – variant with a model selector.
 - `pages/chatgpt-ui.js` – version that stores messages in local storage (default home page).
 - `pages/chatgpt-persistent.js` – simplified UI that also persists messages.
@@ -116,7 +116,7 @@ Key files implementing the chat interface:
 - `pages/cursor-ai-ui.js` – Cursor AI interface with persistent messages and Up-arrow recall.
 - `pages/chatgpt-stream.js` – streams responses token by token.
 - `pages/chatgpt-ui-stream.js` – combines streaming replies with persistent messages.
-- `pages/chatgpt-markdown.js` – renders messages using Markdown.
+- `pages/chatgpt-markdown.js` – renders messages using GitHub-flavored Markdown.
 - `pages/chatgpt-advanced.js` – choose a model and system prompt.
 - `pages/api/chatgpt-stream.js` – API route powering the streaming UI.
 

--- a/components/ChatBubbleMarkdown.js
+++ b/components/ChatBubbleMarkdown.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 export default function ChatBubbleMarkdown({ message }) {
   const isUser = message.role === 'user';
@@ -31,7 +32,7 @@ export default function ChatBubbleMarkdown({ message }) {
                   : 'bg-white text-gray-900 border-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600'
               }`}
             >
-              <ReactMarkdown>{message.text}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.text}</ReactMarkdown>
             </div>
             <button
               onClick={handleCopy}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "next": "13.4.13",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-markdown": "8.0.7"
+    "react-markdown": "8.0.7",
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.14",


### PR DESCRIPTION
## Summary
- render GitHub-flavored Markdown in chat bubbles
- document GFM support for persistent ChatGPT UI

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `node validate.js`


------
https://chatgpt.com/codex/tasks/task_e_68a71eb3ff988328bef0cc0e6b63bf64