### PR TITLE
feat: open markdown links in new tabs

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -1,6 +1,6 @@
 # ChatGPT UI Quick Start
 
-This repository includes a ChatGPT UI with persistent conversations built with Next.js and the OpenAI API. The home page now defaults to this interface (also available at `/chatgpt-ui`) and renders replies using GitHub-flavored Markdown for formatted output. A basic non-persistent interface remains available at `/chatgpt`. Follow these steps to run it locally:
+This repository includes a ChatGPT UI with persistent conversations built with Next.js and the OpenAI API. The home page now defaults to this interface (also available at `/chatgpt-ui`) and renders replies using GitHub-flavored Markdown for formatted output. Links in replies automatically open in a new browser tab. A basic non-persistent interface remains available at `/chatgpt`. Follow these steps to run it locally:
 
 1. Install dependencies if needed:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Google Mobile Ads (`react-native-google-mobile-ads` @15.2.0) is integrated and a
 ## ChatGPT UI
 
 The site now defaults to the persistent ChatGPT UI on the home page (`/`).
-This interface renders replies using GitHub-flavored Markdown, so code blocks, tables, and formatting appear as expected.
+This interface renders replies using GitHub-flavored Markdown, so code blocks, tables, and formatting appear as expected. Links in responses automatically open in a new tab.
 You can still access the simple, non-persistent interface at `/chatgpt`.
 
 To run it locally:

--- a/components/ChatBubbleMarkdown.js
+++ b/components/ChatBubbleMarkdown.js
@@ -32,7 +32,16 @@ export default function ChatBubbleMarkdown({ message }) {
                   : 'bg-white text-gray-900 border-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600'
               }`}
             >
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.text}</ReactMarkdown>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  a: (props) => (
+                    <a {...props} target="_blank" rel="noopener noreferrer" />
+                  ),
+                }}
+              >
+                {message.text}
+              </ReactMarkdown>
             </div>
             <button
               onClick={handleCopy}


### PR DESCRIPTION
## Summary
- open links from markdown chat bubbles in a new tab
- document new link behavior in ChatGPT UI guides

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9282ef25c8328b387f47c00936297