### PR TITLE
Improve ChatGPT UI accessibility

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -43,5 +43,6 @@ You can also save the chat with timestamps as a text file using the **Download**
 Each message now shows a timestamp for when it was sent.
 Each message includes a **Copy** button that briefly displays "Copied!" after copying.
 The message input automatically expands to fit longer content.
+The chat log announces updates to screen readers and indicates when a response is loading.
 Press Shift+Enter to add a newline.
 An animated typing indicator appears while waiting for a response.

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -133,6 +133,7 @@ export default function ChatGptUIPersist() {
           className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4"
           role="log"
           aria-live="polite"
+          aria-busy={loading}
         >
           {messages.map((msg, idx) => (
             <ChatBubbleMarkdown key={idx} message={msg} />


### PR DESCRIPTION
## Summary
- enhance persistent ChatGPT UI with `aria-busy` to signal loading state
- document screen-reader improvements in ChatGPT UI quick start guide

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab2ab5a96883288e2f7e10742d25da