### PR TITLE
Display model name in chat UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -23,6 +23,13 @@ OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 \
 OPENAI_SYSTEM_MESSAGE="You are a helpful assistant." npm run dev
 ```
 
+   To display the active model name in the header, also set
+   `NEXT_PUBLIC_OPENAI_MODEL`:
+
+```bash
+NEXT_PUBLIC_OPENAI_MODEL=gpt-4 npm run dev
+```
+
 3. Open `http://localhost:3000/` in your browser.
 
 Other pages to explore:

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ To run it locally:
 1. Set the required `OPENAI_API_KEY` environment variable. You can copy
    `.env.example` to `.env.local` and add your key there. Optionally
    specify `OPENAI_MODEL` to change the default model and
-   `OPENAI_SYSTEM_MESSAGE` to include a custom system prompt. You can also run
-   the server inline with the key:
+   `OPENAI_SYSTEM_MESSAGE` to include a custom system prompt. To show the active model name in the header, set `NEXT_PUBLIC_OPENAI_MODEL`.
+   You can also run the server inline with the key:
    ```bash
    OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 \
-   OPENAI_SYSTEM_MESSAGE="You are a helpful assistant." npm run dev
+   OPENAI_SYSTEM_MESSAGE="You are a helpful assistant." \
+   NEXT_PUBLIC_OPENAI_MODEL=gpt-4 npm run dev
    ```
 2. Start the dev server:
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -9,13 +9,14 @@
    npm install
    ```
 2. `.env.example` 파일을 `.env.local`로 복사한 뒤 `OPENAI_API_KEY`를 입력합니다.
-   기본 모델을 변경하려면 `OPENAI_MODEL`도 지정한 후 개발 서버를 실행합니다:
+   기본 모델을 변경하려면 `OPENAI_MODEL`도 지정하고,
+   헤더에 모델 이름을 표시하려면 `NEXT_PUBLIC_OPENAI_MODEL`도 설정한 후 개발 서버를 실행합니다:
    ```bash
    npm run dev
    ```
    또는 다음처럼 한 줄로 실행할 수 있습니다:
    ```bash
-   OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 npm run dev
+   OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 NEXT_PUBLIC_OPENAI_MODEL=gpt-4 npm run dev
    ```
 3. 브라우저에서 `http://localhost:3000` 을 열어 대화를 시작합니다.
 

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -16,6 +16,7 @@ export default function ChatGptUIPersist() {
   const endRef = useRef(null);
   const inputRef = useRef(null);
   const disableSend = loading || !input.trim();
+  const modelName = process.env.NEXT_PUBLIC_OPENAI_MODEL;
 
   const handleInputChange = (e) => {
     setInput(e.target.value);
@@ -123,16 +124,24 @@ export default function ChatGptUIPersist() {
         <title>ChatGPT UI (Persistent)</title>
       </Head>
       <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-        <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
-          <DarkModeToggle />
-          <ClearChatButton onClear={handleClear} />
-          <ExportChatButton messages={messages} />
-          <DownloadChatButton messages={messages} />
-        </div>
-        <div
-          className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4"
-          role="log"
-          aria-live="polite"
+      <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">
+        <DarkModeToggle />
+        <ClearChatButton onClear={handleClear} />
+        <ExportChatButton messages={messages} />
+        <DownloadChatButton messages={messages} />
+        {modelName && (
+          <span
+            className="ml-auto text-sm text-gray-500 dark:text-gray-400 self-center"
+            aria-label={`Model ${modelName}`}
+          >
+            Model: {modelName}
+          </span>
+        )}
+      </div>
+      <div
+        className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-900 p-4"
+        role="log"
+        aria-live="polite"
           aria-busy={loading}
         >
           {messages.map((msg, idx) => (


### PR DESCRIPTION
## Summary
- show active OpenAI model in persistent chat UI header when NEXT_PUBLIC_OPENAI_MODEL is set
- document NEXT_PUBLIC_OPENAI_MODEL usage in quick start and readmes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac57c883248328a25cba727ea4fcf1