### PR TITLE
feat: display message count in ChatGPT UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -49,6 +49,7 @@ An **Export** button lets you copy the chat history—including timestamps—to 
 You can also save the chat with timestamps as a text file using the **Download** button.
 Each message now shows a timestamp for when it was sent.
 Each message includes a **Copy** button that briefly displays "Copied!" after copying.
+The header displays the current number of messages in the conversation.
 The message input automatically expands to fit longer content.
 The chat log announces updates to screen readers and indicates when a response is loading.
 Press Shift+Enter to add a newline.

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -129,9 +129,17 @@ export default function ChatGptUIPersist() {
         <ClearChatButton onClear={handleClear} />
         <ExportChatButton messages={messages} />
         <DownloadChatButton messages={messages} />
-        {modelName && (
+        {messages.length > 0 && (
           <span
             className="ml-auto text-sm text-gray-500 dark:text-gray-400 self-center"
+            aria-label={`${messages.length} ${messages.length === 1 ? 'message' : 'messages'}`}
+          >
+            {messages.length} {messages.length === 1 ? 'message' : 'messages'}
+          </span>
+        )}
+        {modelName && (
+          <span
+            className={`${messages.length > 0 ? '' : 'ml-auto '}text-sm text-gray-500 dark:text-gray-400 self-center`}
             aria-label={`Model ${modelName}`}
           >
             Model: {modelName}


### PR DESCRIPTION
## Summary
- show total message count in ChatGPT UI header
- document message count indicator in ChatGPT UI quick start

## Testing
- `npm test` *(fails: Missing script "test")*
- `node validate.js`


------
https://chatgpt.com/codex/tasks/task_e_68b04cf88dc88328b327b54c6dc3b945