### PR TITLE
feat: improve copy button accessibility

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -48,7 +48,7 @@ All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start
 An **Export** button lets you copy the chat history—including timestamps—to your clipboard.
 You can also save the chat with timestamps as a text file using the **Download** button.
 Each message now shows a timestamp for when it was sent.
-Each message includes a **Copy** button that briefly displays "Copied!" after copying.
+Each message includes a **Copy** button that briefly displays "Copied!" after copying and announces the status to screen readers.
 The header displays the current number of messages in the conversation.
 The message input automatically expands to fit longer content.
 The chat log announces updates to screen readers and indicates when a response is loading.

--- a/components/ChatBubbleMarkdown.js
+++ b/components/ChatBubbleMarkdown.js
@@ -48,7 +48,7 @@ export default function ChatBubbleMarkdown({ message }) {
               className="text-xs text-blue-500 hover:underline mt-1"
               aria-label="Copy message"
             >
-              {copied ? 'Copied!' : 'Copy'}
+              <span aria-live="polite">{copied ? 'Copied!' : 'Copy'}</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- announce copy button feedback to screen readers
- document accessible copy feedback in ChatGPT UI guide

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b30e45fe208328ab1a35ffaec91e2c