### PR TITLE
feat: show placeholder in ChatGPT UI when conversation is empty

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -52,5 +52,6 @@ Each message includes a **Copy** button that briefly displays "Copied!" after co
 The header displays the current number of messages in the conversation.
 The message input automatically expands to fit longer content.
 The chat log announces updates to screen readers and indicates when a response is loading.
+If there are no messages yet, a placeholder invites you to start the conversation.
 Press Shift+Enter to add a newline.
 An animated typing indicator appears while waiting for a response.

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -152,6 +152,14 @@ export default function ChatGptUIPersist() {
         aria-live="polite"
           aria-busy={loading}
         >
+          {messages.length === 0 && !loading && (
+            <div
+              className="text-center text-gray-500 dark:text-gray-400 mt-4"
+              aria-label="No messages yet"
+            >
+              No messages yet. Start the conversation below.
+            </div>
+          )}
           {messages.map((msg, idx) => (
             <ChatBubbleMarkdown key={idx} message={msg} />
           ))}


### PR DESCRIPTION
## Summary
- show a friendly placeholder in the ChatGPT UI when there are no messages yet
- document the new placeholder behavior in `CHATGPT_UI.md`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b74b905083289bf4757352545606