### PR TITLE
feat: show message count in page title

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -50,6 +50,7 @@ You can also save the chat with timestamps as a text file using the **Download**
 Each message now shows a timestamp for when it was sent.
 Each message includes a **Copy** button that briefly displays "Copied!" after copying and announces the status to screen readers.
 The header displays the current number of messages in the conversation and announces updates to screen readers.
+The page title also updates with the current message count so you can see new activity from another tab.
 The message input automatically expands to fit longer content.
 The chat log announces updates to screen readers and indicates when a response is loading.
 If there are no messages yet, a placeholder invites you to start the conversation.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ There's also a **Download** button to save the conversation as a timestamped tex
 Each message now has a small **Copy** button that briefly shows "Copied!" after you copy its text.
 The message input supports multi-line entries; press Shift+Enter for a new line.
 The **Send** button stays disabled until you type a message or while waiting for a reply.
+The page title updates with the current number of messages so you can track activity from other browser tabs.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -17,6 +17,8 @@ export default function ChatGptUIPersist() {
   const inputRef = useRef(null);
   const disableSend = loading || !input.trim();
   const modelName = process.env.NEXT_PUBLIC_OPENAI_MODEL;
+  const messageCount = messages.length;
+  const title = `ChatGPT UI (Persistent)${messageCount ? ` - ${messageCount} message${messageCount > 1 ? 's' : ''}` : ''}`;
 
   const handleInputChange = (e) => {
     setInput(e.target.value);
@@ -121,7 +123,7 @@ export default function ChatGptUIPersist() {
   return (
     <>
       <Head>
-        <title>ChatGPT UI (Persistent)</title>
+        <title>{title}</title>
       </Head>
       <div className="flex flex-col h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       <div className="p-2 border-b bg-white dark:bg-gray-800 dark:border-gray-700 flex gap-2">


### PR DESCRIPTION
## Summary
- display message count in the browser tab title for persistent ChatGPT UI
- document the dynamic title in ChatGPT UI quick start and main README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b832edbe408328a02e750b06718145