### PR TITLE
feat: highlight code blocks in chat replies

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -1,6 +1,6 @@
 # ChatGPT UI Quick Start
 
-This repository includes a ChatGPT UI with persistent conversations built with Next.js and the OpenAI API. The home page now defaults to this interface (also available at `/chatgpt-ui`) and renders replies using GitHub-flavored Markdown for formatted output. Links in replies automatically open in a new browser tab. A basic non-persistent interface remains available at `/chatgpt`. Follow these steps to run it locally:
+This repository includes a ChatGPT UI with persistent conversations built with Next.js and the OpenAI API. The home page now defaults to this interface (also available at `/chatgpt-ui`) and renders replies using GitHub-flavored Markdown with syntax highlighting for code blocks. Links in replies automatically open in a new browser tab. A basic non-persistent interface remains available at `/chatgpt`. Follow these steps to run it locally:
 
 1. Install dependencies if needed:
 

--- a/components/ChatBubbleMarkdown.js
+++ b/components/ChatBubbleMarkdown.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 export default function ChatBubbleMarkdown({ message }) {
   const isUser = message.role === 'user';
@@ -38,6 +40,23 @@ export default function ChatBubbleMarkdown({ message }) {
                   a: (props) => (
                     <a {...props} target="_blank" rel="noopener noreferrer" />
                   ),
+                  code({ node, inline, className, children, ...props }) {
+                    const match = /language-(\w+)/.exec(className || '');
+                    return !inline && match ? (
+                      <SyntaxHighlighter
+                        style={oneDark}
+                        language={match[1]}
+                        PreTag="div"
+                        {...props}
+                      >
+                        {String(children).replace(/\n$/, '')}
+                      </SyntaxHighlighter>
+                    ) : (
+                      <code className={className} {...props}>
+                        {children}
+                      </code>
+                    );
+                  },
                 }}
               >
                 {message.text}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-markdown": "8.0.7",
+    "react-syntax-highlighter": "^15.5.0",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- render code blocks in chat responses with syntax highlighting
- document code highlighting feature for ChatGPT UI

## Testing
- `node validate.js`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot resolve 'react-syntax-highlighter')*


------
https://chatgpt.com/codex/tasks/task_e_68ba3ab4e650832893132556f85e8952