### PR TITLE
feat: add keyboard shortcut for clearing chat

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -49,6 +49,7 @@ Other pages to explore:
 - `/cursor-ai-ui` – Cursor-inspired interface with persistent history and Up-arrow recall.
 
 All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation; the message input refocuses automatically.
+Press **Alt+Shift+C** to clear the chat from anywhere on the page after a confirmation prompt.
 An **Export** button lets you copy the chat history—including timestamps—to your clipboard.
 You can also save the chat with timestamps as a text file using the **Download** button.
 Each message now shows a timestamp for when it was sent.

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import Head from 'next/head';
 import ChatBubbleMarkdown from '@/components/ChatBubbleMarkdown';
 import DarkModeToggle from '@/components/DarkModeToggle';
@@ -28,7 +28,7 @@ export default function ChatGptUIPersist() {
     }
   };
 
-  const handleClear = () => {
+  const handleClear = useCallback(() => {
     setMessages([]);
     try {
       localStorage.removeItem(STORAGE_KEY);
@@ -39,7 +39,20 @@ export default function ChatGptUIPersist() {
       inputRef.current.focus();
       inputRef.current.style.height = 'auto';
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    const shortcutHandler = (e) => {
+      if (e.altKey && e.shiftKey && e.key.toLowerCase() === 'c') {
+        e.preventDefault();
+        if (window.confirm('Clear chat history?')) {
+          handleClear();
+        }
+      }
+    };
+    window.addEventListener('keydown', shortcutHandler);
+    return () => window.removeEventListener('keydown', shortcutHandler);
+  }, [handleClear]);
 
   // Load messages from local storage on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- allow clearing the chat with Alt+Shift+C
- document the new shortcut

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd69ed47c883288e3ee1d6c5993dcb