### PR TITLE
feat: add up-arrow recall to ChatGPT UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -60,4 +60,5 @@ The message input automatically expands to fit longer content.
 The chat log announces updates to screen readers and indicates when a response is loading.
 If there are no messages yet, a placeholder invites you to start the conversation.
 Press Shift+Enter to add a newline.
+Press Up Arrow in an empty input to recall your last message.
 An animated typing indicator appears while waiting for a response.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ An **Export** button copies the current conversation—including timestamps—to
 There's also a **Download** button to save the conversation as a timestamped text file.
 Each message now has a small **Copy** button that briefly shows "Copied!" after you copy its text.
 The message input supports multi-line entries; press Shift+Enter for a new line.
+Press Up-arrow in an empty input to recall your last message.
 The **Send** button stays disabled until you type a message or while waiting for a reply.
 The page title updates with the current number of messages so you can track activity from other browser tabs.
 Each message now displays a timestamp for when it was sent.
@@ -116,7 +117,7 @@ Key files implementing the chat interface:
 - `components/ChatBubble.js` – the message bubble component.
 - `components/ChatBubbleMarkdown.js` – bubble with GitHub-flavored Markdown support.
 - `pages/gpt.js` – variant with a model selector.
-- `pages/chatgpt-ui.js` – version that stores messages in local storage (default home page).
+  - `pages/chatgpt-ui.js` – version that stores messages in local storage with Up-arrow recall (default home page).
 - `pages/chatgpt-persistent.js` – simplified UI that also persists messages.
 - `pages/chatgpt-ko.js` – Korean language interface.
 - `pages/cursor-ai-ui.js` – Cursor AI interface with persistent messages and Up-arrow recall.

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -127,7 +127,18 @@ export default function ChatGptUIPersist() {
   };
 
   const handleKeyDown = (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'ArrowUp' && !input.trim()) {
+      const lastUser = [...messages].reverse().find((m) => m.role === 'user');
+      if (lastUser) {
+        setInput(lastUser.text);
+        requestAnimationFrame(() => {
+          if (inputRef.current) {
+            inputRef.current.style.height = 'auto';
+            inputRef.current.style.height = `${inputRef.current.scrollHeight}px`;
+          }
+        });
+      }
+    } else if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(e);
     }


### PR DESCRIPTION
## Summary
- allow pressing Up arrow to recall last message in persistent ChatGPT UI
- document Up-arrow recall in quick start and README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bedcdd61748328b2cea6a0b97cff74