### PR TITLE
feat: show model in page title

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -23,7 +23,7 @@ OPENAI_API_KEY=your-key OPENAI_MODEL=gpt-4 \
 OPENAI_SYSTEM_MESSAGE="You are a helpful assistant." npm run dev
 ```
 
-   To display the active model name in the header, also set
+   To display the active model name in the header and page title, also set
    `NEXT_PUBLIC_OPENAI_MODEL`:
 
 ```bash

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -18,7 +18,8 @@ export default function ChatGptUIPersist() {
   const disableSend = loading || !input.trim();
   const modelName = process.env.NEXT_PUBLIC_OPENAI_MODEL;
   const messageCount = messages.length;
-  const title = `ChatGPT UI (Persistent)${messageCount ? ` - ${messageCount} message${messageCount > 1 ? 's' : ''}` : ''}`;
+  const titleBase = `ChatGPT UI (Persistent)${modelName ? ` - ${modelName}` : ''}`;
+  const title = `${titleBase}${messageCount ? ` - ${messageCount} message${messageCount > 1 ? 's' : ''}` : ''}`;
 
   const handleInputChange = (e) => {
     setInput(e.target.value);


### PR DESCRIPTION
## Summary
- display selected OpenAI model in page title for ChatGPT UI
- document that NEXT_PUBLIC_OPENAI_MODEL affects header and title

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0228415708328be7cc9ac697323d6