### PR TITLE
feat: show model and message count in stream UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -56,6 +56,7 @@ Each message now shows a timestamp for when it was sent.
 Each message includes a **Copy** button that briefly displays "Copied!" after copying and announces the status to screen readers.
 The header displays the current number of messages in the conversation and announces updates to screen readers.
 The page title also updates with the current message count so you can see new activity from another tab.
+If `NEXT_PUBLIC_OPENAI_MODEL` is set, the active model name appears in the header and page title.
 The message input automatically expands to fit longer content.
 The chat log announces updates to screen readers and indicates when a response is loading.
 If there are no messages yet, a placeholder invites you to start the conversation.


### PR DESCRIPTION
## Summary
- display active model name in ChatGPT Stream UI header and page title
- show message count in Stream UI title and header
- support Alt+Shift+C shortcut and Up Arrow recall in Stream UI; document model-name display

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `node validate.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1b3e996708328a7beeec9dd965130