### PR TITLE
Improve ChatBubble copy button accessibility

### DIFF
--- a/components/ChatBubble.js
+++ b/components/ChatBubble.js
@@ -43,7 +43,7 @@ export default function ChatBubble({ message }) {
               className="text-xs text-blue-500 hover:underline mt-1"
               aria-label="Copy message"
             >
-              {copied ? 'Copied!' : 'Copy'}
+              <span aria-live="polite">{copied ? 'Copied!' : 'Copy'}</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- announce copy button status to screen readers in ChatBubble

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c34642f0608328bfa403177a8b6a71