### PR TITLE
feat: add inline status to chat export and download

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -50,8 +50,8 @@ Other pages to explore:
 
 All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation; the message input refocuses automatically.
 Press **Alt+Shift+C** to clear the chat from anywhere on the page after a confirmation prompt.
-An **Export** button lets you copy the chat history—including timestamps—to your clipboard.
-You can also save the chat with timestamps as a text file using the **Download** button.
+An **Export** button copies the chat history—including timestamps—to your clipboard and briefly confirms success.
+You can also save the chat with timestamps as a text file using the **Download** button, which shows a short confirmation message.
 Each message now shows a timestamp for when it was sent.
 Each message includes a **Copy** button that briefly displays "Copied!" after copying and announces the status to screen readers.
 The header displays the current number of messages in the conversation and announces updates to screen readers.

--- a/components/DownloadChatButton.js
+++ b/components/DownloadChatButton.js
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function DownloadChatButton({ messages, label = 'Download' }) {
+  const [status, setStatus] = useState('');
+
   const handleDownload = () => {
     const text = messages
-      .map(m => `${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`)
+      .map((m) => `${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`)
       .join('\n');
     const blob = new Blob([text], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
@@ -12,6 +14,8 @@ export default function DownloadChatButton({ messages, label = 'Download' }) {
     a.download = 'chat.txt';
     a.click();
     URL.revokeObjectURL(url);
+    setStatus('Downloaded!');
+    setTimeout(() => setStatus(''), 2000);
   };
 
   return (
@@ -20,7 +24,7 @@ export default function DownloadChatButton({ messages, label = 'Download' }) {
       className="border px-2 py-1 rounded text-sm bg-white dark:bg-gray-700 dark:text-gray-100"
       aria-label={label}
     >
-      {label}
+      <span aria-live="polite">{status || label}</span>
     </button>
   );
 }

--- a/components/ExportChatButton.js
+++ b/components/ExportChatButton.js
@@ -1,16 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function ExportChatButton({ messages, label = 'Export' }) {
+  const [status, setStatus] = useState('');
+
   const handleExport = async () => {
     const text = messages
-      .map(m => `${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`)
+      .map((m) => `${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`)
       .join('\n');
     try {
       await navigator.clipboard.writeText(text);
-      alert('Chat copied to clipboard');
+      setStatus('Copied!');
     } catch (err) {
-      alert('Failed to copy chat: ' + err.message);
+      setStatus('Copy failed');
     }
+    setTimeout(() => setStatus(''), 2000);
   };
 
   return (
@@ -19,7 +22,7 @@ export default function ExportChatButton({ messages, label = 'Export' }) {
       className="border px-2 py-1 rounded text-sm bg-white dark:bg-gray-700 dark:text-gray-100"
       aria-label={label}
     >
-      {label}
+      <span aria-live="polite">{status || label}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- show temporary status messages for chat export and download actions
- remove blocking alerts and replace with screen-reader friendly updates
- document new confirmation behavior for export and download buttons

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c57c69755c8328b77c7127d6472794