### PR TITLE
feat: show clear status in ChatGPT UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -48,7 +48,7 @@ Other pages to explore:
 - `/chatgpt-ui-markdown` – persistent UI with GitHub-flavored Markdown.
 - `/cursor-ai-ui` – Cursor-inspired interface with persistent history and Up-arrow recall.
 
-All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation; the message input refocuses automatically.
+All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation; after clearing it briefly shows "Cleared!" and the message input refocuses automatically.
 Press **Alt+Shift+C** to clear the chat from anywhere on the page after a confirmation prompt.
 An **Export** button copies the chat history—including timestamps—to your clipboard and briefly confirms success.
 You can also save the chat with timestamps as a text file using the **Download** button, which shows a short confirmation message.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ A Korean interface is available at `/chatgpt-ko`.
 A Cursor-inspired interface is available at `/cursor-ai-ui`, with persistent messages, auto-resizing input, and Up-arrow recall of your last prompt.
 All chat pages now include a **Dark Mode** toggle in the header. If you haven't
 set a preference, the toggle follows your system's color scheme by default.
-You can also reset the conversation anytime using the **Clear** button, which now asks for confirmation before deleting the chat.
+You can also reset the conversation anytime using the **Clear** button, which asks for confirmation and briefly shows "Cleared!" after removing the chat.
 An **Export** button copies the current conversation—including timestamps—to your clipboard.
 There's also a **Download** button to save the conversation as a timestamped text file.
 Each message now has a small **Copy** button that briefly shows "Copied!" after you copy its text.

--- a/components/ClearChatButton.js
+++ b/components/ClearChatButton.js
@@ -1,13 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function ClearChatButton({
   onClear,
   label = 'Clear',
   confirmMessage = 'Clear chat history?'
 }) {
+  const [status, setStatus] = useState('');
   const handleClick = () => {
     if (window.confirm(confirmMessage)) {
       onClear();
+      setStatus('Cleared!');
+      setTimeout(() => setStatus(''), 2000);
     }
   };
 
@@ -17,7 +20,7 @@ export default function ClearChatButton({
       className="border px-2 py-1 rounded text-sm bg-white dark:bg-gray-700 dark:text-gray-100"
       aria-label={label}
     >
-      {label}
+      <span aria-live="polite">{status || label}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- show temporary "Cleared!" confirmation after clearing chat
- document clear status behavior in README and quick start guide

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6e2548174832890cde51945b4ce28