### PR TITLE
Add Escape key shortcut to clear ChatGPT UI input

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -62,4 +62,5 @@ The chat log announces updates to screen readers and indicates when a response i
 If there are no messages yet, a placeholder invites you to start the conversation.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
+Press Escape to clear the message input.
 An animated typing indicator appears while waiting for a response.

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -139,6 +139,11 @@ export default function ChatGptUIPersist() {
           }
         });
       }
+    } else if (e.key === 'Escape') {
+      setInput('');
+      if (inputRef.current) {
+        inputRef.current.style.height = 'auto';
+      }
     } else if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(e);


### PR DESCRIPTION
## Summary
- allow Esc key to clear chat input in persistent ChatGPT UI
- document Esc shortcut in ChatGPT UI README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c80c641c8c8328b63694a2a99ccb8a