### PR TITLE
Add ChatGPT UI settings panel and starter prompts

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -49,9 +49,13 @@ Other pages to explore:
 - `/cursor-ai-ui` – Cursor-inspired interface with persistent history and Up-arrow recall.
 
 All chat pages include a **Dark Mode** toggle. Use the **Clear** button to start a fresh conversation; after clearing it briefly shows "Cleared!" and the message input refocuses automatically.
+Use the **Settings** button in the header to define a custom system prompt. The prompt is saved locally, applied to every
+message you send, and included in exports or downloads so you retain full context when sharing conversations.
 Press **Alt+Shift+C** to clear the chat from anywhere on the page after a confirmation prompt.
-An **Export** button copies the chat history—including timestamps—to your clipboard and briefly confirms success.
-You can also save the chat with timestamps as a text file using the **Download** button, which shows a short confirmation message.
+An **Export** button copies the chat history—including timestamps and the custom system prompt when set—to your clipboard and
+briefly confirms success.
+You can also save the chat with timestamps as a text file using the **Download** button, which shows a short confirmation message
+and now names the file using the current timestamp.
 Each message now shows a timestamp for when it was sent.
 Each message includes a **Copy** button that briefly displays "Copied!" after copying and announces the status to screen readers.
 The header displays the current number of messages in the conversation and announces updates to screen readers.
@@ -59,7 +63,8 @@ The page title also updates with the current message count so you can see new ac
 If `NEXT_PUBLIC_OPENAI_MODEL` is set, the active model name appears in the header and page title.
 The message input automatically expands to fit longer content.
 The chat log announces updates to screen readers and indicates when a response is loading.
-If there are no messages yet, a placeholder invites you to start the conversation.
+If there are no messages yet, a placeholder invites you to start the conversation and now displays quick-start prompt cards for
+common workflows.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
 Press Escape to clear the message input.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The site now defaults to the persistent ChatGPT UI on the home page (`/`).
 This interface renders replies using GitHub-flavored Markdown, so code blocks, tables, and formatting appear as expected. Links in responses automatically open in a new tab.
 You can still access the simple, non-persistent interface at `/chatgpt`.
 
+Open the **Settings** button in the header to define a custom system prompt. The prompt is saved locally, applied to every
+message you send, and included whenever you export or download the transcript. A few starter prompts now appear on an empty
+conversation so you can jump into common workflows without typing everything from scratch.
+
 To run it locally:
 
 1. Set the required `OPENAI_API_KEY` environment variable. You can copy
@@ -95,6 +99,7 @@ set a preference, the toggle follows your system's color scheme by default.
 You can also reset the conversation anytime using the **Clear** button, which asks for confirmation and briefly shows "Cleared!" after removing the chat.
 An **Export** button copies the current conversation—including timestamps—to your clipboard.
 There's also a **Download** button to save the conversation as a timestamped text file.
+Exports and downloads now include the active system prompt (when set) so you have the full context later.
 Each message now has a small **Copy** button that briefly shows "Copied!" after you copy its text.
 The message input supports multi-line entries; press Shift+Enter for a new line.
 Press Up-arrow in an empty input to recall your last message.
@@ -104,6 +109,7 @@ Each message now displays a timestamp for when it was sent.
 The header shows the current message count and, if set, the active model name.
 An animated typing indicator appears while waiting for a response, and the chat log announces updates to screen readers while indicating when a reply is loading.
 If there are no messages yet, a placeholder invites you to start the conversation, and the message input automatically expands to fit longer content.
+Quick-start prompt cards also appear to help you compose your first message.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 

--- a/components/DownloadChatButton.js
+++ b/components/DownloadChatButton.js
@@ -1,17 +1,15 @@
 import React, { useState } from 'react';
 
-export default function DownloadChatButton({ messages, label = 'Download' }) {
+export default function DownloadChatButton({ messages, label = 'Download', systemPrompt = '' }) {
   const [status, setStatus] = useState('');
 
   const handleDownload = () => {
-    const text = messages
-      .map((m) => `${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`)
-      .join('\n');
-    const blob = new Blob([text], { type: 'text/plain' });
+    const formatted = buildTranscript(messages, systemPrompt);
+    const blob = new Blob([formatted], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'chat.txt';
+    a.download = createFilename();
     a.click();
     URL.revokeObjectURL(url);
     setStatus('Downloaded!');
@@ -27,4 +25,21 @@ export default function DownloadChatButton({ messages, label = 'Download' }) {
       <span aria-live="polite">{status || label}</span>
     </button>
   );
+}
+
+function buildTranscript(messages, systemPrompt) {
+  const trimmedPrompt = typeof systemPrompt === 'string' ? systemPrompt.trim() : '';
+  const lines = [];
+  if (trimmedPrompt) {
+    lines.push(`system: ${trimmedPrompt}`);
+  }
+  for (const m of messages) {
+    lines.push(`${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`);
+  }
+  return lines.join('\n');
+}
+
+function createFilename() {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return `chat-${timestamp}.txt`;
 }

--- a/components/ExportChatButton.js
+++ b/components/ExportChatButton.js
@@ -1,14 +1,12 @@
 import React, { useState } from 'react';
 
-export default function ExportChatButton({ messages, label = 'Export' }) {
+export default function ExportChatButton({ messages, label = 'Export', systemPrompt = '' }) {
   const [status, setStatus] = useState('');
 
   const handleExport = async () => {
-    const text = messages
-      .map((m) => `${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`)
-      .join('\n');
+    const formatted = buildTranscript(messages, systemPrompt);
     try {
-      await navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(formatted);
       setStatus('Copied!');
     } catch (err) {
       setStatus('Copy failed');
@@ -25,4 +23,16 @@ export default function ExportChatButton({ messages, label = 'Export' }) {
       <span aria-live="polite">{status || label}</span>
     </button>
   );
+}
+
+function buildTranscript(messages, systemPrompt) {
+  const trimmedPrompt = typeof systemPrompt === 'string' ? systemPrompt.trim() : '';
+  const lines = [];
+  if (trimmedPrompt) {
+    lines.push(`system: ${trimmedPrompt}`);
+  }
+  for (const m of messages) {
+    lines.push(`${m.role}${m.time ? ` (${m.time})` : ''}: ${m.text}`);
+  }
+  return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
- add a settings panel that persists a custom system prompt, surfaces it in the header, and sends it with API calls
- surface quick-start prompt suggestions on an empty conversation with helpers to prefill the input
- include the custom prompt when exporting or downloading chats and update the docs accordingly

## Testing
- npm run build *(fails: Next.js reports several existing pages without a valid default export)*

------
https://chatgpt.com/codex/tasks/task_e_68caad2a36dc8328a1c65559032c5474