### PR TITLE
Add searchable prompt library drawer to chat UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -65,6 +65,8 @@ The message input automatically expands to fit longer content.
 The chat log announces updates to screen readers and indicates when a response is loading.
 If there are no messages yet, a placeholder invites you to start the conversation and now displays quick-start prompt cards for
 common workflows.
+Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords before
+dropping them into the chat.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
 Press Escape to clear the message input.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The header shows the current message count and, if set, the active model name.
 An animated typing indicator appears while waiting for a response, and the chat log announces updates to screen readers while indicating when a reply is loading.
 If there are no messages yet, a placeholder invites you to start the conversation, and the message input automatically expands to fit longer content.
 Quick-start prompt cards also appear to help you compose your first message.
+Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
+before inserting it into the chat box.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 


### PR DESCRIPTION
## Summary
- add a prompt library drawer to the persistent ChatGPT UI, including search, keyboard shortcuts, and focus management
- wire the drawer into the header controls and empty-state helper text so curated starters are available during any conversation
- document the new prompt library option in the ChatGPT UI quick start guide and main README

## Testing
- npm run build > /tmp/build.log && tail -n 20 /tmp/build.log

------
https://chatgpt.com/codex/tasks/task_e_68cbfdd92990832883d2a7b10ca6e1d7