### PR TITLE
Add tagged prompt suggestions to ChatGPT UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -65,8 +65,9 @@ The message input automatically expands to fit longer content.
 The chat log announces updates to screen readers and indicates when a response is loading.
 If there are no messages yet, a placeholder invites you to start the conversation and now displays quick-start prompt cards for
 common workflows.
-Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords before
-dropping them into the chat.
+The cards include themed badges to help you scan suggestions at a glance, plus a new starter for writing pull request summaries with testing callouts.
+Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags
+before dropping them into the chat.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
 Press Escape to clear the message input.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ The header shows the current message count and, if set, the active model name.
 An animated typing indicator appears while waiting for a response, and the chat log announces updates to screen readers while indicating when a reply is loading.
 If there are no messages yet, a placeholder invites you to start the conversation, and the message input automatically expands to fit longer content.
 Quick-start prompt cards also appear to help you compose your first message.
+Each card shows themed badges so you can quickly spot the right starting point, including a new prompt for drafting pull request summaries with testing notes.
 Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
-before inserting it into the chat box.
+or tag before inserting it into the chat box.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -16,24 +16,36 @@ const promptSuggestions = [
     description: 'Turn long notes into concise action items.',
     prompt:
       'Summarize the following meeting transcript into concise action items and key decisions:\n\n',
+    tags: ['Meetings', 'Summaries'],
   },
   {
     title: 'Draft release notes',
     description: 'Highlight what changed in a friendly tone.',
     prompt:
       'Create release notes for the following list of updates. Include a short intro and grouped bullet points:\n\n',
+    tags: ['Product', 'Announcements'],
   },
   {
     title: 'Explain a concept',
     description: 'Request an accessible explanation with examples.',
     prompt:
       'Explain the following concept to a new developer. Use a real-world analogy and list common pitfalls:\n\n',
+    tags: ['Education', 'Guides'],
+  },
+  {
+    title: 'Draft a pull request summary',
+    description: 'Capture key changes and how they were tested.',
+    prompt:
+      'Write a concise pull request summary for the following changes. Call out the motivation, key updates, and any tests run:' +
+      '\n\n',
+    tags: ['Collaboration', 'Pull Request'],
   },
   {
     title: 'Brainstorm ideas',
     description: 'Generate creative approaches for a problem.',
     prompt:
       'Brainstorm five creative feature ideas for a productivity app that helps remote teams collaborate asynchronously.',
+    tags: ['Productivity', 'Ideation'],
   },
 ];
 
@@ -103,11 +115,17 @@ export default function ChatGptUIPersist() {
   const filteredPromptSuggestions = useMemo(() => {
     const search = promptSearch.trim().toLowerCase();
     if (!search) return promptSuggestions;
-    return promptSuggestions.filter((suggestion) =>
-      suggestion.title.toLowerCase().includes(search) ||
-      suggestion.description.toLowerCase().includes(search) ||
-      suggestion.prompt.toLowerCase().includes(search)
-    );
+    return promptSuggestions.filter((suggestion) => {
+      if (
+        suggestion.title.toLowerCase().includes(search) ||
+        suggestion.description.toLowerCase().includes(search) ||
+        suggestion.prompt.toLowerCase().includes(search)
+      ) {
+        return true;
+      }
+      if (!suggestion.tags?.length) return false;
+      return suggestion.tags.some((tag) => tag.toLowerCase().includes(search));
+    });
   }, [promptSearch]);
 
   const handleSystemPromptChange = (e) => {
@@ -409,11 +427,23 @@ export default function ChatGptUIPersist() {
                       <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
                         {suggestion.description}
                       </span>
+                      {suggestion.tags?.length > 0 && (
+                        <span className="mt-2 flex flex-wrap gap-1">
+                          {suggestion.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[0.65rem] font-medium uppercase tracking-wide text-blue-700 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-200"
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </span>
+                      )}
                     </button>
                   ))}
                 </div>
                 <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
-                  Looking for more inspiration? Open the <span className="font-medium">Prompt library</span> from the header to browse every saved starter.
+                  Looking for more inspiration? Open the <span className="font-medium">Prompt library</span> from the header to browse every saved starter. The badges show the themes each prompt is best suited for.
                 </p>
               </div>
             </div>
@@ -468,7 +498,8 @@ export default function ChatGptUIPersist() {
                   Prompt library
                 </h2>
                 <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                  Browse curated starters or search to quickly reuse a favorite request.
+                  Browse curated starters or search to quickly reuse a favorite request. Results match titles, descriptions,
+                  prompts, and badges.
                 </p>
               </div>
               <button
@@ -489,7 +520,7 @@ export default function ChatGptUIPersist() {
                 type="search"
                 value={promptSearch}
                 onChange={(event) => setPromptSearch(event.target.value)}
-                placeholder="Search prompts by title or keyword"
+                placeholder="Search prompts by title, keyword, or tag"
                 className="w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
               />
             </div>
@@ -516,6 +547,18 @@ export default function ChatGptUIPersist() {
                         <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
                           {suggestion.description}
                         </span>
+                        {suggestion.tags?.length > 0 && (
+                          <span className="mt-2 flex flex-wrap gap-1">
+                            {suggestion.tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[0.65rem] font-medium uppercase tracking-wide text-blue-700 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-200"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </span>
+                        )}
                       </button>
                     </li>
                   ))}


### PR DESCRIPTION
## Summary
- add themed badge metadata to the ChatGPT UI quick-start cards and prompt library
- extend prompt filtering so searches also match the new tags
- document the pull-request starter prompt and tagged browsing experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd51ec1bd4832888c305edf8a39b64