### PR TITLE
Add PR helper modal and template to chat UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -68,6 +68,7 @@ common workflows.
 The cards include themed badges to help you scan suggestions at a glance, plus a new starter for writing pull request summaries with testing callouts.
 Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags
 before dropping them into the chat.
+Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary and Testing template you can tweak or insert into the composer.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
 Press Escape to clear the message input.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Quick-start prompt cards also appear to help you compose your first message.
 Each card shows themed badges so you can quickly spot the right starting point, including a new prompt for drafting pull request summaries with testing notes.
 Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
 or tag before inserting it into the chat box.
+Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary and Testing template before sharing updates.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 


### PR DESCRIPTION
## Summary
- add a PR helper modal to the persistent chat UI with a reusable summary/testing template that can be copied or inserted into the composer
- expand prompt suggestions with a verification plan starter and update the empty state messaging to highlight the helper
- document the new helper workflow in the README and ChatGPT UI quick-start guide

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce95d367808328a0c687d7b5964fac