### PR TITLE
Update PR helper with screenshot guidance

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -68,7 +68,7 @@ common workflows.
 The cards include themed badges to help you scan suggestions at a glance, plus a new starter for writing pull request summaries with testing callouts.
 Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags
 before dropping them into the chat.
-Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary and Testing template—now seeded with file and log citation placeholders—you can tweak or insert into the composer.
+Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Screenshots, and Testing template—now seeded with file, log, and image citation placeholders—you can tweak or insert into the composer.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
 Press Escape to clear the message input.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Quick-start prompt cards also appear to help you compose your first message.
 Each card shows themed badges so you can quickly spot the right starting point, including a new prompt for drafting pull request summaries with testing notes.
 Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
 or tag before inserting it into the chat box.
-Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary and Testing template—complete with citation placeholders—before sharing updates.
+Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—complete with citation placeholders and reminders to document UI changes—before sharing updates.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -34,9 +34,9 @@ const promptSuggestions = [
   },
   {
     title: 'Draft a pull request summary',
-    description: 'Capture key changes, test coverage, and where to cite supporting context.',
+    description: 'Capture key changes, test coverage, and where to cite supporting context or screenshots.',
     prompt:
-      'Write a concise pull request summary for the following changes. Include the motivation, the key updates, tests that ran, and call out where the supporting files or logs should be cited:' +
+      'Write a concise pull request summary for the following changes. Include the motivation, the key updates, tests that ran, and call out where the supporting files, logs, or screenshots should be cited:' +
       '\n\n',
     tags: ['Collaboration', 'Pull Request'],
   },
@@ -59,6 +59,9 @@ const promptSuggestions = [
 const DEFAULT_PR_TEMPLATE = `Summary
 * Highlight 1. 【F:path/to/file†L#-L#】
 * Highlight 2. 【F:path/to/file†L#-L#】
+
+Screenshots (if applicable)
+* ![Screenshot description](artifacts/filename.png)
 
 Testing
 * ✅ ${'`'}command or suite${'`'} – passed. 【chunk†L#-L#】
@@ -547,7 +550,7 @@ export default function ChatGptUIPersist() {
                   Looking for more inspiration? Open the <span className="font-medium">Prompt library</span> from the header to browse every saved starter. The badges show the themes each prompt is best suited for.
                 </p>
                 <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-                  Preparing a pull request? The <span className="font-medium">PR helper</span> button offers a ready-to-edit summary and testing template complete with citation placeholders you can copy or drop into the composer.
+                  Preparing a pull request? The <span className="font-medium">PR helper</span> button offers a ready-to-edit summary, screenshot, and testing template complete with citation placeholders you can copy or drop into the composer.
                 </p>
               </div>
             </div>
@@ -708,7 +711,7 @@ export default function ChatGptUIPersist() {
             <div className="px-6 py-4 space-y-4">
               <div>
                 <p id="pr-helper-tip" className="text-xs text-gray-500 dark:text-gray-400">
-                  Swap the emoji to ⚠️ or ❌ if a check is flaky or failing, replace the placeholders with project details, and update the citation markers with the relevant files or command output.
+                  Swap the emoji to ⚠️ or ❌ if a check is flaky or failing, replace the placeholders with project details, call out screenshots when you tweak the UI, and update the citation markers with the relevant files or command output.
                 </p>
                 <textarea
                   ref={prHelperTextareaRef}


### PR DESCRIPTION
## Summary
- expand the pull request prompt helper to mention citing screenshots alongside files and logs
- add a screenshots section to the default PR template and update in-app helper guidance
- refresh the documentation to note the new screenshot reminders in the PR helper

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1a3acd20c83288f36175dcb533816