### PR TITLE
Update PR helper template to use bold section headings

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -68,7 +68,7 @@ common workflows.
 The cards include themed badges to help you scan suggestions at a glance, plus a new starter for writing pull request summaries with testing callouts.
 Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags
 before dropping them into the chat.
-Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Screenshots, and Testing template—now seeded with file, log, and image citation placeholders—you can tweak or insert into the composer.
+Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Screenshots, and Testing template—now with bold section headers plus file, log, and image citation placeholders—you can tweak or insert into the composer.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
 Press Escape to clear the message input.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Quick-start prompt cards also appear to help you compose your first message.
 Each card shows themed badges so you can quickly spot the right starting point, including a new prompt for drafting pull request summaries with testing notes.
 Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
 or tag before inserting it into the chat box.
-Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—complete with citation placeholders and reminders to document UI changes—before sharing updates.
+Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, citation placeholders, and reminders to document UI changes—before sharing updates.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 


### PR DESCRIPTION
## Summary
- bold the default PR helper template headings so the Summary and Testing sections match the latest handoff guidance
- update the quick-add logic to recognize bold Testing headings while inserting additional status rows
- refresh inline helper copy and documentation to call out the bold section headers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3e9a580fc832892be0ff1dd3002e8