### PR TITLE
Enhance PR helper quick-add sections

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -68,7 +68,7 @@ common workflows.
 The cards include themed badges to help you scan suggestions at a glance, plus a new starter for writing pull request summaries with testing callouts.
 Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags
 before dropping them into the chat.
-Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Screenshots, and Testing template—now with bold section headers plus file, log, and image citation placeholders—you can tweak or insert into the composer.
+Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Screenshots, and Testing template—now with bold section headers, quick-add buttons for Impact, Accessibility, Performance, Rollout, and Testing rows, plus file, log, and image citation placeholders you can tweak or insert into the composer.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
 Press Escape to clear the message input.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Quick-start prompt cards also appear to help you compose your first message.
 Each card shows themed badges so you can quickly spot the right starting point, including a new prompt for drafting pull request summaries with testing notes.
 Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
 or tag before inserting it into the chat box.
-Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, citation placeholders, and reminders to document UI changes—before sharing updates.
+Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, quick-add buttons for Impact, Accessibility, Performance, Rollout, or additional test rows, and citation placeholders so you remember to document UI changes—before sharing updates.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 


### PR DESCRIPTION
## Summary
- expand the default PR helper template with Impact & Risks, Rollout, and Known issues callouts
- add quick-add controls for Impact, Accessibility, Performance, and Rollout sections that refocus the editor
- refresh the ChatGPT UI docs to mention the richer PR helper capabilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5c65f44f08328962981710b94e338