### PR TITLE
Enhance chat header stats and PR helper snippets

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -60,6 +60,7 @@ Tap the **Insights** button in the header to review message counts, role balance
 Each message now shows a timestamp for when it was sent.
 Each message includes a **Copy** button that briefly displays "Copied!" after copying and announces the status to screen readers.
 The header displays the current number of messages in the conversation and announces updates to screen readers.
+It now also surfaces the conversation span, average words per message, and the timestamp of the last reply so you can gauge pace without opening the Insights panel.
 The page title also updates with the current message count so you can see new activity from another tab.
 If `NEXT_PUBLIC_OPENAI_MODEL` is set, the active model name appears in the header and page title.
 The message input automatically expands to fit longer content.
@@ -69,7 +70,7 @@ common workflows.
 The cards include themed badges to help you scan suggestions at a glance, plus a new starter for writing pull request summaries with testing callouts.
 Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags
 before dropping them into the chat.
-Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Accessibility, Performance, Analytics & Monitoring, Screenshots, and Testing template—now with bold section headers, quick-add buttons for Impact, Security & Privacy, Accessibility, Performance, Analytics & Monitoring, Rollout, Documentation, and Testing rows, plus file, log, and image citation placeholders you can tweak or insert into the composer.
+Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Accessibility, Performance, Analytics & Monitoring, Screenshots, and Testing template—now with bold section headers, quick-add buttons for Impact, Security & Privacy, Accessibility, Performance, Analytics & Monitoring, Rollout, Documentation, and Testing rows (each inserting emoji-prefixed ✅/⚠️/❌ snippets automatically), plus file, log, and image citation placeholders you can tweak or insert into the composer.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
 Press Escape to clear the message input.

--- a/README.md
+++ b/README.md
@@ -107,13 +107,14 @@ The **Send** button stays disabled until you type a message or while waiting for
 The page title updates with the current number of messages so you can track activity from other browser tabs.
 Each message now displays a timestamp for when it was sent.
 The header shows the current message count and, if set, the active model name.
+It also surfaces the conversation span, average words per message, and the timestamp of the last reply so you can see progress at a glance.
 An animated typing indicator appears while waiting for a response, and the chat log announces updates to screen readers while indicating when a reply is loading.
 If there are no messages yet, a placeholder invites you to start the conversation, and the message input automatically expands to fit longer content.
 Quick-start prompt cards also appear to help you compose your first message.
 Each card shows themed badges so you can quickly spot the right starting point, including a new prompt for drafting pull request summaries with testing notes.
 Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
 or tag before inserting it into the chat box.
-Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, quick-add buttons for Impact, Accessibility, Performance, Rollout, or additional test rows, and citation placeholders so you remember to document UI changes—before sharing updates.
+Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, quick-add buttons for Impact, Accessibility, Performance, Rollout, or additional test rows (now inserting ✅/⚠️/❌ markdown snippets automatically), and citation placeholders so you remember to document UI changes—before sharing updates.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -80,7 +80,7 @@ const DEFAULT_PR_TEMPLATE = [
   '* ![Screenshot description](artifacts/filename.png)',
   '',
   '**Testing**',
-  '* ✅ `command or suite` – Passed locally. 【chunk†L#-L#】',
+  '* ✅ `command or suite` — Passed locally. 【chunk†L#-L#】',
   '',
   '**Documentation & Support**',
   '* Release notes, runbooks, or help-center updates to keep in sync. 【F:path/to/file†L#-L#】',
@@ -93,9 +93,9 @@ const DEFAULT_PR_TEMPLATE = [
 ].join('\n');
 
 const PR_TEST_SNIPPETS = {
-  pass: '* ✅ `command or suite` – Passed locally. 【chunk†L#-L#】',
-  warn: '* ⚠️ `command or suite` – Needs follow-up or is flaky. 【chunk†L#-L#】',
-  fail: '* ❌ `command or suite` – Failing and requires attention. 【chunk†L#-L#】',
+  pass: '* ✅ `command or suite` — Passed locally. 【chunk†L#-L#】',
+  warn: '* ⚠️ `command or suite` — Needs follow-up or is flaky. 【chunk†L#-L#】',
+  fail: '* ❌ `command or suite` — Failing and requires attention. 【chunk†L#-L#】',
 };
 
 const PR_SECTION_SNIPPETS = [
@@ -1073,14 +1073,29 @@ export default function ChatGptUIPersist() {
             {showSettings ? 'Hide settings' : 'Settings'}
           </button>
           <div className="ml-auto flex flex-wrap gap-x-4 gap-y-1 items-center text-sm text-gray-500 dark:text-gray-400">
-            {messages.length > 0 && (
-              <span
-                className="self-center"
-                aria-label={`${messages.length} ${messages.length === 1 ? 'message' : 'messages'}`}
-                aria-live="polite"
-              >
-                {messages.length} {messages.length === 1 ? 'message' : 'messages'}
-              </span>
+            {hasMessages && (
+              <>
+                <span
+                  className="self-center"
+                  aria-label={`${messages.length} ${messages.length === 1 ? 'message' : 'messages'}`}
+                  aria-live="polite"
+                >
+                  {messages.length} {messages.length === 1 ? 'message' : 'messages'}
+                </span>
+                {conversationDurationText && (
+                  <span className="self-center" aria-label={`Conversation span ${conversationDurationText}`}>
+                    Span: {conversationDurationText}
+                  </span>
+                )}
+                <span className="self-center" aria-label={`Average words per message ${averageWordsPerMessageDisplay}`}>
+                  Avg words/msg: {averageWordsPerMessageDisplay}
+                </span>
+                {lastReplyDisplay && (
+                  <span className="self-center" aria-label={`Last reply ${lastReplyDisplay}`}>
+                    Last reply: {lastReplyDisplay}
+                  </span>
+                )}
+              </>
             )}
             {modelName && (
               <span className="self-center" aria-label={`Model ${modelName}`}>


### PR DESCRIPTION
## Summary
- show conversation duration, average words per message, and last reply timing inline in the ChatGPT UI header for quicker context
- align the default PR template and quick-add testing snippets with emoji-prefixed guidance and document the changes

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68da939211b88328911b2834db8b022d