### PR TITLE
Add draft length indicator to chat UI and refine PR helper template

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -63,7 +63,7 @@ The header displays the current number of messages in the conversation and annou
 It now also surfaces the conversation span, average words per message, and the timestamp of the last reply so you can gauge pace without opening the Insights panel.
 The page title also updates with the current message count so you can see new activity from another tab.
 If `NEXT_PUBLIC_OPENAI_MODEL` is set, the active model name appears in the header and page title.
-The message input automatically expands to fit longer content.
+The message input automatically expands to fit longer content and now shows live word and character counts for your draft so you can spot lengthy updates before sending them.
 The chat log announces updates to screen readers and indicates when a response is loading.
 If there are no messages yet, a placeholder invites you to start the conversation and now displays quick-start prompt cards for
 common workflows.

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -58,8 +58,9 @@ const promptSuggestions = [
 
 const DEFAULT_PR_TEMPLATE = [
   '**Summary**',
-  '* Highlight 1. 【F:path/to/file†L#-L#】',
-  '* Highlight 2. 【F:path/to/file†L#-L#】',
+  '* Motivation and background. 【F:path/to/file†L#-L#】',
+  '* Key implementation changes. 【F:path/to/file†L#-L#】',
+  '* Follow-up guardrails or next steps. 【F:path/to/file†L#-L#】',
   '',
   '**Impact & Risks**',
   '* Who is affected and what trade-offs or mitigations should reviewers note?',
@@ -256,6 +257,11 @@ export default function ChatGptUIPersist() {
   const insightsDialogRef = useRef(null);
   const insightsHasOpened = useRef(false);
   const disableSend = loading || !input.trim();
+  const draftWordCount = countWords(input);
+  const draftCharacterCount = input.length;
+  const draftStatsText = `Draft length: ${formatNumber(draftWordCount)} ${
+    draftWordCount === 1 ? 'word' : 'words'
+  } · ${formatNumber(draftCharacterCount)} ${draftCharacterCount === 1 ? 'char' : 'chars'}`;
   const modelName = process.env.NEXT_PUBLIC_OPENAI_MODEL;
   const messageCount = messages.length;
   const titleBase = `ChatGPT UI (Persistent)${modelName ? ` - ${modelName}` : ''}`;
@@ -1275,6 +1281,7 @@ export default function ChatGptUIPersist() {
                     : 'Draft your first request to start a new conversation.'}
                 </span>
                 <div className="flex flex-wrap gap-x-3 gap-y-1">
+                  <span aria-live="polite">{draftStatsText}</span>
                   <span>{trimmedSystemPrompt ? 'Custom system prompt active' : 'Default system prompt'}</span>
                   <span>Autosaves locally</span>
                 </div>


### PR DESCRIPTION
## Summary
- show live draft word and character counts alongside the chat composer metadata
- expand the default PR helper summary rows to call out motivation, implementation details, and follow-up guardrails
- document the new draft length indicator in the ChatGPT UI guide

## Testing
- npm run build *(fails: Next.js export cannot locate several pre-rendered pages in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc6ccb8a08328aa0513e278d4bb0e