### PR TITLE
Persist PR helper template edits in ChatGPT UI

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -70,7 +70,7 @@ common workflows.
 The cards include themed badges to help you scan suggestions at a glance, plus a new starter for writing pull request summaries with testing callouts.
 Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags
 before dropping them into the chat.
-Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Accessibility, Performance, Analytics & Monitoring, Screenshots, and Testing template—now with bold section headers, quick-add buttons for Impact, Security & Privacy, Accessibility, Performance, Analytics & Monitoring, Rollout, Documentation, and Testing rows (each inserting emoji-prefixed ✅/⚠️/❌ snippets automatically), plus file, log, and image citation placeholders you can tweak or insert into the composer.
+Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Accessibility, Performance, Analytics & Monitoring, Screenshots, and Testing template—now with bold section headers, quick-add buttons for Impact, Security & Privacy, Accessibility, Performance, Analytics & Monitoring, Rollout, Documentation, and Testing rows (each inserting emoji-prefixed ✅/⚠️/❌ snippets automatically), plus file, log, and image citation placeholders you can tweak or insert into the composer. Any edits you make to the template are saved locally so you can revisit or refine them later.
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.
 Press Escape to clear the message input.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Quick-start prompt cards also appear to help you compose your first message.
 Each card shows themed badges so you can quickly spot the right starting point, including a new prompt for drafting pull request summaries with testing notes.
 Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
 or tag before inserting it into the chat box.
-Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, quick-add buttons for Impact, Accessibility, Performance, Rollout, or additional test rows (now inserting ✅/⚠️/❌ markdown snippets automatically), and citation placeholders so you remember to document UI changes—before sharing updates.
+Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, quick-add buttons for Impact, Security & Privacy, Accessibility, Performance, Analytics & Monitoring, Documentation, Rollout, or additional test rows (now inserting ✅/⚠️/❌ markdown snippets automatically), and citation placeholders so you remember to document UI changes—before sharing updates. Your edits to the template persist locally, so you can refine the draft and return to it even after refreshing the page.
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).
 Korean instructions are available in [README_KO.md](./README_KO.md).
 

--- a/pages/chatgpt-ui.js
+++ b/pages/chatgpt-ui.js
@@ -9,6 +9,7 @@ import TypingIndicator from '@/components/TypingIndicator';
 
 const STORAGE_KEY = 'chatgptMessages';
 const SETTINGS_KEY = 'chatgptUiSettings';
+const PR_TEMPLATE_STORAGE_KEY = 'chatgptUiPrTemplate';
 
 const promptSuggestions = [
   {
@@ -92,6 +93,7 @@ const DEFAULT_PR_TEMPLATE = [
   '**Known issues**',
   '* Outstanding bugs, limitations, or tickets to monitor.',
 ].join('\n');
+const DEFAULT_PR_TEMPLATE_TRIMMED = DEFAULT_PR_TEMPLATE.trim();
 
 const PR_TEST_SNIPPETS = {
   pass: '* ✅ `command or suite` — Passed locally. 【chunk†L#-L#】',
@@ -253,6 +255,7 @@ export default function ChatGptUIPersist() {
   const prHelperButtonRef = useRef(null);
   const prHelperTextareaRef = useRef(null);
   const prHelperHasOpened = useRef(false);
+  const prTemplateHydrated = useRef(false);
   const insightsButtonRef = useRef(null);
   const insightsDialogRef = useRef(null);
   const insightsHasOpened = useRef(false);
@@ -844,6 +847,36 @@ export default function ChatGptUIPersist() {
       console.error('Failed to save chat settings', err);
     }
   }, [systemPrompt]);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(PR_TEMPLATE_STORAGE_KEY);
+      if (typeof saved === 'string' && saved.trim()) {
+        setPrTemplateText(saved);
+      }
+    } catch (err) {
+      console.error('Failed to load PR helper template', err);
+    } finally {
+      prTemplateHydrated.current = true;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!prTemplateHydrated.current) {
+      return;
+    }
+
+    try {
+      const trimmed = prTemplateText.trim();
+      if (!trimmed || trimmed === DEFAULT_PR_TEMPLATE_TRIMMED) {
+        localStorage.removeItem(PR_TEMPLATE_STORAGE_KEY);
+      } else {
+        localStorage.setItem(PR_TEMPLATE_STORAGE_KEY, prTemplateText);
+      }
+    } catch (err) {
+      console.error('Failed to save PR helper template', err);
+    }
+  }, [prTemplateText]);
 
   useEffect(() => {
     if (endRef.current) {
@@ -1470,6 +1503,9 @@ export default function ChatGptUIPersist() {
                   rows={8}
                   className="mt-3 w-full rounded border border-gray-300 bg-white p-3 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
                 />
+                <p className="mt-2 text-[0.7rem] text-gray-500 dark:text-gray-400">
+                  Edits save locally so you can revisit the draft later. Use Reset template to restore the default outline.
+                </p>
               </div>
               <div>
                 <p className="text-xs text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- persist the ChatGPT PR helper template in local storage and indicate that edits are saved locally
- document the persistent template behavior in the README and ChatGPT UI quick-start guide

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd25e90064832884803f6ed4401169