### PR TITLE
Enhance ChatGPT UI insights and PR helper

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -56,11 +56,11 @@ An **Export** button copies the chat history—including timestamps and the cust
 briefly confirms success.
 You can also save the chat with timestamps as a text file using the **Download** button, which shows a short confirmation message
 and now names the file using the current timestamp.
-Tap the **Insights** button in the header to review message counts, role balance, word totals, and conversation timing, then copy a shareable summary for docs or pull requests.
+Tap the **Insights** button in the header to review message counts, role balance, word totals, word-share percentages, the longest update and pause, and conversation timing, then copy a shareable summary for docs or pull requests.
 Each message now shows a timestamp for when it was sent.
 Each message includes a **Copy** button that briefly displays "Copied!" after copying and announces the status to screen readers.
 The header displays the current number of messages in the conversation and announces updates to screen readers.
-It now also surfaces the conversation span, average words per message, and the timestamp of the last reply so you can gauge pace without opening the Insights panel.
+It now also surfaces the conversation span, average words per message, the longest update so far, the longest pause between replies, and the timestamp of the last reply so you can gauge pace without opening the Insights panel.
 The page title also updates with the current message count so you can see new activity from another tab.
 If `NEXT_PUBLIC_OPENAI_MODEL` is set, the active model name appears in the header and page title.
 The message input automatically expands to fit longer content and now shows live word and character counts for your draft so you can spot lengthy updates before sending them.
@@ -71,7 +71,7 @@ The cards include themed badges to help you scan suggestions at a glance, plus r
 Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags
 before dropping them into the chat.
 
-Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Accessibility, Performance, Analytics & Monitoring, Screenshots, and Testing template—now with bold section headers, quick-add buttons for Impact, Security & Privacy, Accessibility, Performance, Analytics & Monitoring, Rollout, Documentation, evidence bullets (logs, screenshots, docs), and Testing rows (each inserting emoji-prefixed ✅/⚠️/❌ snippets automatically), plus file, log, and image citation placeholders you can tweak or insert into the composer.
+Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Accessibility, User Experience, Performance, Analytics & Monitoring, Screenshots, and Testing template—now with bold section headers, quick-add buttons for Impact, Security & Privacy, Accessibility, User Experience, Performance, Analytics & Monitoring, Rollout, Documentation, evidence bullets (logs, metrics, screenshots, docs, videos), and Testing rows (each inserting emoji-prefixed ✅/⚠️/❌ snippets automatically), plus file, log, and image citation placeholders you can tweak or insert into the composer.
 
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.

--- a/README.md
+++ b/README.md
@@ -107,14 +107,15 @@ The **Send** button stays disabled until you type a message or while waiting for
 The page title updates with the current number of messages so you can track activity from other browser tabs.
 Each message now displays a timestamp for when it was sent.
 The header shows the current message count and, if set, the active model name.
-It also surfaces the conversation span, average words per message, and the timestamp of the last reply so you can see progress at a glance.
+It also surfaces the conversation span, average words per message, the longest update so far, the longest pause between replies, and the timestamp of the last reply so you can see progress at a glance.
 An animated typing indicator appears while waiting for a response, and the chat log announces updates to screen readers while indicating when a reply is loading.
 If there are no messages yet, a placeholder invites you to start the conversation, and the message input automatically expands to fit longer content.
 Quick-start prompt cards also appear to help you compose your first message.
 Each card shows themed badges so you can quickly spot the right starting point, including refreshed prompts for summarizing change sets, planning rollout messaging, and drafting pull request summaries with testing notes.
 Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
 or tag before inserting it into the chat box.
-Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, quick-add buttons for Impact, Accessibility, Performance, Rollout, Documentation, evidence bullets (logs, screenshots, docs), or additional test rows (now inserting ✅/⚠️/❌ markdown snippets automatically), and citation placeholders so you remember to document UI changes—before sharing updates.
+Want a quick pulse check on the conversation? Tap the **Insights** button in the header to review message counts, word totals, word-share balance, the longest update and pause, and a copy-ready summary you can drop into docs or follow-up prompts.
+Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, quick-add buttons for Impact, Accessibility, User Experience, Performance, Analytics & Monitoring, Rollout, Documentation, evidence bullets (logs, metrics, screenshots, docs, videos), or additional test rows (now inserting ✅/⚠️/❌ markdown snippets automatically), and citation placeholders so you remember to document UI changes—before sharing updates.
 
 
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).


### PR DESCRIPTION
## Summary
- surface the longest update, longest pause, and word-share data in the persistent ChatGPT UI header and insights modal
- expand the insights summary with word share plus per-role longest update details while persisting new metrics
- enrich the PR helper with a default **User Experience** section, new quick-add buttons for UX, metrics, and video evidence, and refresh supporting documentation

## Testing
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc3378f60832892089ba68a698c3c