### PR TITLE
Add prompt favorites and regression risk PR helper snippet

### DIFF
--- a/CHATGPT_UI.md
+++ b/CHATGPT_UI.md
@@ -67,11 +67,10 @@ The message input automatically expands to fit longer content and now shows live
 The chat log announces updates to screen readers and indicates when a response is loading.
 If there are no messages yet, a placeholder invites you to start the conversation and now displays quick-start prompt cards for
 common workflows.
-The cards include themed badges to help you scan suggestions at a glance, plus refreshed starters for summarizing change sets, planning rollout messaging, and writing pull request summaries with testing callouts.
-Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags
-before dropping them into the chat.
+The cards include themed badges to help you scan suggestions at a glance, plus refreshed starters for summarizing change sets, planning rollout messaging, and writing pull request summaries with testing callouts. Tap the star in the corner of a card to favorite it—favorites jump to the top of the quick-start grid and stay pinned in the Prompt library for speedy reuse.
+Open the **Prompt library** button in the header at any time to browse the full set of starters or search for keywords or tags before dropping them into the chat. Favorited prompts sync automatically so your go-to requests are always nearby.
 
-Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Accessibility, User Experience, Performance, Analytics & Monitoring, Screenshots, and Testing template—now with bold section headers, quick-add buttons for Impact, Security & Privacy, Accessibility, User Experience, Performance, Analytics & Monitoring, Rollout, Documentation, evidence bullets (logs, metrics, screenshots, docs, videos), and Testing rows (each inserting emoji-prefixed ✅/⚠️/❌ snippets automatically), plus file, log, and image citation placeholders you can tweak or insert into the composer.
+Need to summarize a change set? Tap the **PR helper** for a copy-ready Summary, Accessibility, User Experience, Performance, Analytics & Monitoring, Screenshots, and Testing template—now with bold section headers, quick-add buttons for Impact, Regression risks, Security & Privacy, Accessibility, User Experience, Performance, Analytics & Monitoring, Rollout, Documentation, evidence bullets (logs, metrics, screenshots, docs, videos), and Testing rows (each inserting emoji-prefixed ✅/⚠️/❌ snippets automatically), plus file, log, and image citation placeholders you can tweak or insert into the composer.
 
 Press Shift+Enter to add a newline.
 Press Up Arrow in an empty input to recall your last message.

--- a/README.md
+++ b/README.md
@@ -111,11 +111,10 @@ It also surfaces the conversation span, average words per message, the longest u
 An animated typing indicator appears while waiting for a response, and the chat log announces updates to screen readers while indicating when a reply is loading.
 If there are no messages yet, a placeholder invites you to start the conversation, and the message input automatically expands to fit longer content.
 Quick-start prompt cards also appear to help you compose your first message.
-Each card shows themed badges so you can quickly spot the right starting point, including refreshed prompts for summarizing change sets, planning rollout messaging, and drafting pull request summaries with testing notes.
-Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword
-or tag before inserting it into the chat box.
+Each card shows themed badges so you can quickly spot the right starting point, including refreshed prompts for summarizing change sets, planning rollout messaging, and drafting pull request summaries with testing notes. Mark a card with the star button to favorite it—favorites float to the top of the quick-start grid and stay pinned inside the Prompt library so you can reuse your go-to starters faster.
+Need inspiration mid-conversation? Tap the **Prompt library** button in the header to browse every starter or search by keyword or tag before inserting it into the chat box. Favorites sync automatically here too, so your most-used prompts are always within reach.
 Want a quick pulse check on the conversation? Tap the **Insights** button in the header to review message counts, word totals, word-share balance, the longest update and pause, and a copy-ready summary you can drop into docs or follow-up prompts.
-Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, quick-add buttons for Impact, Accessibility, User Experience, Performance, Analytics & Monitoring, Rollout, Documentation, evidence bullets (logs, metrics, screenshots, docs, videos), or additional test rows (now inserting ✅/⚠️/❌ markdown snippets automatically), and citation placeholders so you remember to document UI changes—before sharing updates.
+Need a quick pull request outline? Open the **PR helper** from the header to copy or tweak a ready-made Summary, Screenshots, and Testing template—with bold section headers, quick-add buttons for Impact, Regression risks, Accessibility, User Experience, Performance, Analytics & Monitoring, Rollout, Documentation, evidence bullets (logs, metrics, screenshots, docs, videos), or additional test rows (now inserting ✅/⚠️/❌ markdown snippets automatically), and citation placeholders so you remember to document UI changes—before sharing updates.
 
 
 For a condensed quick-start guide, see [`CHATGPT_UI.md`](./CHATGPT_UI.md).


### PR DESCRIPTION
## Summary
- allow prompt suggestions to be starred and persist favorites locally while floating them to the top of the quick-start grid and prompt library
- introduce regression risk guidance to the default PR helper template and quick-add buttons
- document the new favorites workflow and regression risk callout in the ChatGPT UI guides

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3c4836d2c8328a62a1133e42679ff