### PR TITLE
Add 90-day launch roadmap and trust/compliance panel to hairloss page

### DIFF
--- a/pages/hairloss.js
+++ b/pages/hairloss.js
@@ -297,6 +297,33 @@ const pricing = [
   },
 ]
 
+const complianceNotes = [
+  'Not a diagnostic tool. The app is designed for early awareness and prevention support.',
+  'All treatment guidance is educational and should be reviewed with a licensed clinician.',
+  'Users control sharing for DNA uploads, specialist referrals, and partner clinic handoffs.',
+]
+
+const rolloutPlan = [
+  {
+    phase: 'Phase 1',
+    timing: 'Weeks 1-4',
+    deliverables:
+      'Launch guided weekly scans, baseline density score, and simple trend visualizations.',
+  },
+  {
+    phase: 'Phase 2',
+    timing: 'Weeks 5-8',
+    deliverables:
+      'Add personalized prevention plans using scalp patterns, lifestyle inputs, and adherence tracking.',
+  },
+  {
+    phase: 'Phase 3',
+    timing: 'Weeks 9-12',
+    deliverables:
+      'Enable specialist referrals, clinic handoff summaries, and partner monetization workflows.',
+  },
+]
+
 export default function HairLoss() {
   return (
     <div className="bg-slate-950 text-white">
@@ -749,6 +776,41 @@ export default function HairLoss() {
                   </ul>
                 </article>
               ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-6xl px-6 pb-24">
+          <div className="grid gap-6 rounded-3xl border border-white/10 bg-gradient-to-br from-slate-900 to-slate-950 p-8 lg:grid-cols-[1.1fr_0.9fr]">
+            <div>
+              <p className="text-sm uppercase tracking-[0.3em] text-emerald-300">Launch roadmap</p>
+              <h3 className="mt-2 text-2xl font-semibold">A 90-day path from waitlist to revenue</h3>
+              <p className="mt-3 text-sm text-slate-300">
+                Manetain can start as a focused prevention product and expand into a repeatable
+                clinic referral channel with measurable outcomes.
+              </p>
+              <div className="mt-6 space-y-4">
+                {rolloutPlan.map((item) => (
+                  <article key={item.phase} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                    <p className="text-xs uppercase tracking-[0.2em] text-emerald-300">{item.phase}</p>
+                    <p className="mt-1 text-sm font-semibold text-white">{item.timing}</p>
+                    <p className="mt-2 text-sm text-slate-300">{item.deliverables}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-emerald-300/20 bg-emerald-500/10 p-5">
+              <p className="text-xs uppercase tracking-[0.2em] text-emerald-200">Trust + compliance</p>
+              <h4 className="mt-2 text-xl font-semibold">Prevention guidance with clear boundaries</h4>
+              <ul className="mt-4 space-y-3 text-sm text-slate-100">
+                {complianceNotes.map((note) => (
+                  <li key={note} className="flex gap-3">
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" />
+                    <span>{note}</span>
+                  </li>
+                ))}
+              </ul>
             </div>
           </div>
         </section>


### PR DESCRIPTION
### Motivation
- Surface a clear 90-day rollout plan so stakeholders can understand phased deliverables from baseline scans to clinic referrals. 
- Explicitly communicate medical and data-sharing boundaries so the product is framed as prevention/education rather than a diagnostic tool. 

### Description
- Added a new `rolloutPlan` data structure that defines three phased milestones for Weeks 1–12 and renders them in a new "Launch roadmap" section on the page (`pages/hairloss.js`).
- Added a new `complianceNotes` array and a "Trust + compliance" panel that lists medical boundary and data-sharing points, reusing the existing `CheckCircle2` icon and Tailwind layout styles.
- Integrated the two datasets into the UI by mapping over `rolloutPlan` and `complianceNotes` to produce styled cards consistent with existing Manetain sections.

### Testing
- Ran `npm run build` to validate the production compile, and the build failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`), not from the changes in `pages/hairloss.js`.
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d2760202e88328a95fd533c80e9eb9)