### PR TITLE
Add Opportunity Overview section to Hair Loss page

### DIFF
--- a/pages/hairloss.js
+++ b/pages/hairloss.js
@@ -297,6 +297,29 @@ const pricing = [
   },
 ]
 
+const opportunitySnapshot = [
+  {
+    title: 'Problem',
+    detail:
+      'Most men notice hair loss too late. Gradual changes blend into daily life, and treatment efficacy drops as progression advances.',
+  },
+  {
+    title: 'Solution',
+    detail:
+      'Weekly AI scalp scans detect density and recession shifts early, then convert insights into prevention recommendations.',
+  },
+  {
+    title: 'Business model',
+    detail:
+      'Freemium access plus clinic referral revenue share and affiliate commissions on trusted treatment recommendations.',
+  },
+  {
+    title: 'End goal',
+    detail:
+      'Become the highest-intent prevention funnel in men’s hair health and a strategic acquisition fit for platforms like Hims.',
+  },
+]
+
 export default function HairLoss() {
   return (
     <div className="bg-slate-950 text-white">
@@ -408,6 +431,24 @@ export default function HairLoss() {
                 <article key={highlight.title} className="rounded-2xl border border-white/10 bg-slate-900/60 p-5">
                   <h3 className="text-sm uppercase tracking-[0.2em] text-emerald-200">{highlight.title}</h3>
                   <p className="mt-2 text-sm text-slate-300">{highlight.description}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="mb-8 rounded-3xl border border-white/10 bg-slate-900/70 p-6">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-sm uppercase tracking-[0.3em] text-emerald-300">Opportunity overview</p>
+                <h2 className="mt-2 text-2xl font-semibold">Hair today, gone tomorrow — unless detection happens early.</h2>
+              </div>
+              <p className="text-xs text-slate-400">Market context: global hair loss treatment market ~ $8.2B</p>
+            </div>
+            <div className="mt-6 grid gap-4 md:grid-cols-2">
+              {opportunitySnapshot.map((item) => (
+                <article key={item.title} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                  <p className="text-xs uppercase tracking-[0.2em] text-emerald-300">{item.title}</p>
+                  <p className="mt-2 text-sm text-slate-300">{item.detail}</p>
                 </article>
               ))}
             </div>


### PR DESCRIPTION
### Motivation
- Surface a concise investor-facing summary (Problem, Solution, Business model, End goal) to make the pitch on the Hair Loss page more scannable and aligned with the product narrative. 
- Provide market context and a short block that connects the investor snapshot to the rest of the product storytelling.

### Description
- Add a new `opportunitySnapshot` data model to `pages/hairloss.js` containing Problem, Solution, Business model, and End goal entries. 
- Render a new “Opportunity overview” section beneath the existing Investor snapshot, including a market-context callout and four structured cards. 
- Keep the new block visually consistent with the page using existing Tailwind classes and the same card/article pattern as nearby sections.

### Testing
- Ran `npm run build`, which executed Next.js checks and an optimized build attempt and failed during compilation. 
- Build failure is caused by pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`) and not by the changes in `pages/hairloss.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d64bbb31a08328a8f51658c9589156)