### PR TITLE
Add “Why now” section and Open Graph metadata to Hair Loss landing page

### DIFF
--- a/pages/hairloss.js
+++ b/pages/hairloss.js
@@ -303,6 +303,24 @@ const complianceNotes = [
   'Users control sharing for DNA uploads, specialist referrals, and partner clinic handoffs.',
 ]
 
+const whyNowPoints = [
+  {
+    title: 'Intervention timing matters',
+    detail:
+      'Most men discover loss after large visible changes, but treatment outcomes are generally strongest when started early.',
+  },
+  {
+    title: 'Computer vision is finally consumer-ready',
+    detail:
+      'Smartphone cameras plus guided capture can now produce repeatable, clinically useful trend signals at home.',
+  },
+  {
+    title: 'Telehealth distribution is mature',
+    detail:
+      'Users can move from detection to specialist consultation in days, not months, which makes early alerts actionable.',
+  },
+]
+
 const rolloutPlan = [
   {
     phase: 'Phase 1',
@@ -332,6 +350,11 @@ export default function HairLoss() {
         <meta
           name="description"
           content="AI-powered hair loss tracking, prevention recommendations, and specialist booking."
+        />
+        <meta property="og:title" content="Manetain — Hair Loss Prevention App" />
+        <meta
+          property="og:description"
+          content="Track hairline and crown changes early with weekly AI scans and personalized prevention guidance."
         />
       </Head>
 
@@ -493,6 +516,21 @@ export default function HairLoss() {
                 Manetain can become the earliest-intent hair prevention funnel in the market, sending
                 treatment-ready users to telehealth and clinic partners with rich longitudinal data.
               </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-6xl px-6 pb-20">
+          <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-slate-900 to-slate-950 p-8">
+            <p className="text-sm uppercase tracking-[0.3em] text-emerald-300">Why now</p>
+            <h3 className="mt-2 text-2xl font-semibold">The market is ready for prevention-first hair health</h3>
+            <div className="mt-6 grid gap-4 md:grid-cols-3">
+              {whyNowPoints.map((point) => (
+                <article key={point.title} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                  <h4 className="text-base font-semibold">{point.title}</h4>
+                  <p className="mt-2 text-sm text-slate-300">{point.detail}</p>
+                </article>
+              ))}
             </div>
           </div>
         </section>


### PR DESCRIPTION
### Motivation
- Strengthen the investor/product narrative on the Hair Loss page by explaining why the market is ripe for a prevention-first product. 
- Improve social sharing and discovery by adding Open Graph metadata for richer previews.

### Description
- Added a new `whyNowPoints` content array to `pages/hairloss.js` containing three market-timing points (intervention timing, computer-vision readiness, telehealth distribution). 
- Added Open Graph meta tags (`og:title`, `og:description`) inside the page `<Head>` for better social previews. 
- Rendered a new **Why now** section that maps over `whyNowPoints` and displays the points using the existing card styling patterns. 

### Testing
- Ran `npm run lint`, which failed because this repository does not define a `lint` script. (failure)
- Ran `npm run build`, which failed due to pre-existing unrelated syntax errors in `pages/lumiere.js` and `pages/mealcycle.js`, so the site build could not complete. (failure)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d79ddd4384832881a7dccd45a679b1)