### PR TITLE
Fix Consendus chat simulation typing indicator state handling

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -310,7 +310,7 @@ export default function Consendus() {
 
     generated.forEach((message, index) => {
       setTimeout(() => {
-        setTypingAgent(message.author)
+        setTypingAgents((prev) => (prev.includes(message.author) ? prev : [...prev, message.author]))
         setMessages((prev) => [
           ...prev,
           {
@@ -323,7 +323,7 @@ export default function Consendus() {
 
         if (index === generated.length - 1) {
           setTimeout(() => {
-            setTypingAgent('')
+            setTypingAgents([])
             setSimulating(false)
           }, 260)
         }
@@ -455,7 +455,7 @@ export default function Consendus() {
               {simulating && (
                 <div className="mt-3 inline-flex items-center gap-2 rounded-md border border-purple-400/30 bg-purple-500/10 px-2.5 py-1 text-xs text-purple-200">
                   <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-purple-300" />
-                  {typingAgent ? `${typingAgent} is typing...` : 'Agent swarm is drafting responses...'}
+                  {typingAgents[0] ? `${typingAgents[0]} is typing...` : 'Agent swarm is drafting responses...'}
                 </div>
               )}
 


### PR DESCRIPTION
### Motivation
- Prevent a runtime error in the Comms view when the `Simulate Activity` flow attempted to call a nonexistent `setTypingAgent` updater and ensure typing-state is tracked consistently.

### Description
- Updated `pages/consendus.js` to use the existing `typingAgents` state consistently during simulation flows by replacing stray `setTypingAgent` calls with `setTypingAgents` updater logic.
- Initialize `typingAgents` when simulation starts and clear it when the simulated sequence finishes to avoid stale UI state.
- Updated the live typing banner to read from `typingAgents[0]` so the “is typing…” label renders from the tracked agents list.

### Testing
- Ran `npm run build` which executed the Next.js production build and failed due to unrelated pre-existing syntax errors in `pages/lumiere.js` and `pages/mealcycle.js`, so the overall build did not complete.
- The change to `pages/consendus.js` no longer references the undefined `setTypingAgent` updater and therefore removes the source of the Comms simulation crash observed prior to this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ef4aa4388328a08264c1baf56f24)