### PR TITLE
Add missing `rolloutPlan` and `complianceNotes` to Hair Loss page

### DIFF
--- a/pages/hairloss.js
+++ b/pages/hairloss.js
@@ -297,6 +297,34 @@ const pricing = [
   },
 ]
 
+
+const rolloutPlan = [
+  {
+    phase: 'Phase 1',
+    timing: 'Days 0-30',
+    deliverables:
+      'Launch waitlist, onboarding flow, and baseline weekly scalp capture with trend scoring.',
+  },
+  {
+    phase: 'Phase 2',
+    timing: 'Days 31-60',
+    deliverables:
+      'Ship personalized prevention recommendations, adherence reminders, and risk alerts.',
+  },
+  {
+    phase: 'Phase 3',
+    timing: 'Days 61-90',
+    deliverables:
+      'Enable specialist booking, referral analytics, and clinic partner revenue workflows.',
+  },
+]
+
+const complianceNotes = [
+  'The app provides prevention guidance and trend tracking, not medical diagnosis.',
+  'Users can escalate to licensed specialists when risk thresholds are crossed.',
+  'Optional DNA data stays user-controlled and is not required for core product value.',
+]
+
 const opportunitySnapshot = [
   {
     title: 'Problem',


### PR DESCRIPTION
### Motivation
- The Launch roadmap and Trust + compliance sections on the Hair Loss page referenced `rolloutPlan` and `complianceNotes` which were undefined, causing runtime errors when rendering that page.

### Description
- Inserted a `rolloutPlan` array (three phased entries) into `pages/hairloss.js` to populate the Launch roadmap UI.
- Inserted a `complianceNotes` array (three guidance strings) into `pages/hairloss.js` to populate the Trust + compliance UI.
- Placed the new constants before `opportunitySnapshot` so the page-level JSX can map over them without referencing undefined identifiers.

### Testing
- Ran `npm run build`; the build attempt failed due to pre-existing syntax errors in unrelated files `pages/lumiere.js` and `pages/mealcycle.js`, and not because of the added constants.
- Confirmed the change is syntactically valid in `pages/hairloss.js` and resolves the undefined identifier usage for `rolloutPlan` and `complianceNotes`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9f729b9083288ffa45b69dc9cea0)