### PR TITLE
Initialize chatScrollRef in Consendus comms panel

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -236,6 +236,7 @@ export default function Consendus() {
   const [simulating, setSimulating] = useState(false)
   const [typingAgent, setTypingAgent] = useState('')
   const [typingAgents, setTypingAgents] = useState([])
+  const chatScrollRef = useRef(null)
 
   const tasksByState = useMemo(
     () =>


### PR DESCRIPTION
### Motivation
- Prevent a runtime null/ref error when auto-scrolling the Comms chat feed by ensuring the scroll target ref is defined before use.

### Description
- Added `const chatScrollRef = useRef(null)` to `pages/consendus.js` alongside the component state so the `useEffect` auto-scroll call has a valid ref target.

### Testing
- Ran `npm run build`; the build failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`) and reported no new errors attributable to the change in `pages/consendus.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcee0ed6308328b72fb8dbdc19d0c1)