### PR TITLE
Fix Comms auto-scroll in Consendus (add chatScrollRef, remove unused state)

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -234,8 +234,8 @@ export default function Consendus() {
   const [activeChannel, setActiveChannel] = useState(channels[0])
   const [messages, setMessages] = useState(initialMessages)
   const [simulating, setSimulating] = useState(false)
-  const [typingAgent, setTypingAgent] = useState('')
   const [typingAgents, setTypingAgents] = useState([])
+  const chatScrollRef = useRef(null)
 
   const tasksByState = useMemo(
     () =>
@@ -306,7 +306,6 @@ export default function Consendus() {
     const generated = pool.sort(() => Math.random() - 0.5).slice(0, targetCount)
 
     setSimulating(true)
-    setTypingAgent('')
     setTypingAgents(generated.map((message) => message.author))
 
     generated.forEach((message, index) => {


### PR DESCRIPTION
### Motivation
- Ensure the Comms view can reliably auto-scroll to the bottom by providing a valid `chatScrollRef` and remove an unused `typingAgent` state to simplify simulation logic.

### Description
- Added `const chatScrollRef = useRef(null)` to `pages/consendus.js` so the existing `useEffect` can call `chatScrollRef.current?.scrollTo(...)` safely.
- Removed the unused `typingAgent` state and the redundant `setTypingAgent('')` call during `appendSimulatedMessages()` to reduce unused state and side effects.

### Testing
- Ran `npm run build`; the build failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`), and not because of changes in `pages/consendus.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de35b649b48328b136dd575afdfb7d)