### PR TITLE
Fix Consendus comms simulation state setup

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -234,8 +234,8 @@ export default function Consendus() {
   const [activeChannel, setActiveChannel] = useState(channels[0])
   const [messages, setMessages] = useState(initialMessages)
   const [simulating, setSimulating] = useState(false)
-  const [typingAgent, setTypingAgent] = useState('')
   const [typingAgents, setTypingAgents] = useState([])
+  const chatScrollRef = useRef(null)
 
   const tasksByState = useMemo(
     () =>
@@ -306,7 +306,6 @@ export default function Consendus() {
     const generated = pool.sort(() => Math.random() - 0.5).slice(0, targetCount)
 
     setSimulating(true)
-    setTypingAgent('')
     setTypingAgents(generated.map((message) => message.author))
 
     generated.forEach((message, index) => {


### PR DESCRIPTION
### Motivation
- Ensure the Comms view auto-scroll logic references a valid ref and remove dead/unused state to keep the simulated-activity flow consistent.

### Description
- Added `chatScrollRef` and wired it into the component so the existing `useEffect` auto-scroll uses a real ref, and removed the unused `typingAgent` state and its reset call in the simulation flow in `pages/consendus.js`.

### Testing
- Ran `npm run build`; the build failed due to pre-existing, unrelated syntax errors in `pages/lumiere.js` and `pages/mealcycle.js`, not because of changes in `pages/consendus.js` (the edits themselves are small and did not introduce new syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8636a5d0832880afb67404844a6a)