### PR TITLE
Add Cuecrew.ai Vite demo app with live studio personas

### DIFF
--- a/cuecrew-ai/index.html
+++ b/cuecrew-ai/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cuecrew.ai</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/cuecrew-ai/package.json
+++ b/cuecrew-ai/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cuecrew-ai",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@google/genai": "^0.7.0",
+    "lucide-react": "^0.473.0",
+    "motion": "^12.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^4.3.4",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5"
+  }
+}

--- a/cuecrew-ai/src/App.tsx
+++ b/cuecrew-ai/src/App.tsx
@@ -1,0 +1,9 @@
+import { useState } from 'react';
+import DemoApp from './DemoApp';
+import LandingPage from './LandingPage';
+
+export default function App() {
+  const [view, setView] = useState<'landing' | 'studio'>('landing');
+
+  return view === 'landing' ? <LandingPage onLaunch={() => setView('studio')} /> : <DemoApp onBack={() => setView('landing')} />;
+}

--- a/cuecrew-ai/src/DemoApp.tsx
+++ b/cuecrew-ai/src/DemoApp.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowLeft, Mic, MicOff, Radio } from 'lucide-react';
+import { motion } from 'motion/react';
+import { getPersonaResponses } from './gemini';
+import type { PersonaResponses, TranscriptSegment } from './types';
+
+type Props = { onBack: () => void };
+
+type SpeechRecognitionType = typeof window.SpeechRecognition;
+
+declare global {
+  interface Window {
+    webkitSpeechRecognition: SpeechRecognitionType;
+    SpeechRecognition: SpeechRecognitionType;
+  }
+}
+
+const personaMeta: { key: keyof PersonaResponses; label: string; color: string }[] = [
+  { key: 'factChecker', label: 'Fact-checker', color: 'var(--color-tag-fact)' },
+  { key: 'contextProvider', label: 'Context Provider', color: 'var(--color-tag-context)' },
+  { key: 'comedyWriter', label: 'Comedy Writer', color: 'var(--color-tag-joke)' },
+  { key: 'newsAnchor', label: 'News Anchor', color: 'var(--color-tag-news)' },
+];
+
+export default function DemoApp({ onBack }: Props) {
+  const [segments, setSegments] = useState<TranscriptSegment[]>([]);
+  const [interimText, setInterimText] = useState('');
+  const [isRecording, setIsRecording] = useState(false);
+  const [fallbackText, setFallbackText] = useState('');
+  const [supportsSpeech, setSupportsSpeech] = useState(true);
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  const latestSegment = useMemo(() => segments.at(-1), [segments]);
+
+  useEffect(() => {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      setSupportsSpeech(false);
+      return;
+    }
+
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+
+    recognition.onresult = (event) => {
+      let interim = '';
+
+      for (let i = event.resultIndex; i < event.results.length; i += 1) {
+        const transcript = event.results[i][0].transcript.trim();
+
+        if (event.results[i].isFinal) {
+          pushFinalSegment(transcript);
+        } else {
+          interim += `${transcript} `;
+        }
+      }
+      setInterimText(interim.trim());
+    };
+
+    recognition.onerror = () => setIsRecording(false);
+    recognition.onend = () => {
+      if (isRecording) recognition.start();
+    };
+
+    recognitionRef.current = recognition;
+    return () => recognition.stop();
+  }, [isRecording]);
+
+  const pushFinalSegment = async (text: string) => {
+    if (!text) return;
+
+    const id = crypto.randomUUID();
+    setSegments((prev) => [...prev, { id, text }]);
+    setInterimText('');
+
+    const personaResponses = await getPersonaResponses(text);
+    setSegments((prev) => prev.map((seg) => (seg.id === id ? { ...seg, personaResponses } : seg)));
+  };
+
+  const toggleRecording = () => {
+    const recognition = recognitionRef.current;
+    if (!recognition) return;
+
+    if (isRecording) {
+      recognition.stop();
+      setIsRecording(false);
+    } else {
+      recognition.start();
+      setIsRecording(true);
+    }
+  };
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden">
+      <header className="flex items-center justify-between border-b border-white/10 px-6 py-4">
+        <div className="flex items-center gap-4">
+          <button onClick={onBack} className="rounded-md border border-white/20 p-2 hover:bg-white/10">
+            <ArrowLeft size={18} />
+          </button>
+          <h1 style={{ fontFamily: 'var(--font-serif)' }}>
+            Cue<span style={{ color: 'var(--color-accent-gold)' }}>crew</span>.ai
+          </h1>
+          <span className="ml-2 flex items-center gap-2 text-sm text-red-400">
+            <motion.span className="h-2 w-2 rounded-full bg-red-500" animate={{ opacity: [1, 0.3, 1] }} transition={{ duration: 1.2, repeat: Infinity }} />
+            Live Studio
+          </span>
+        </div>
+        <button onClick={toggleRecording} className="rounded-full bg-[var(--color-accent-blue)] px-4 py-2 text-black">
+          {isRecording ? 'Stop Recording' : 'Start Recording'}
+        </button>
+      </header>
+
+      <main className="flex min-h-0 flex-1">
+        <section className="relative flex min-h-0 flex-1 flex-col border-r border-white/10">
+          <div className="border-b border-white/10 px-5 py-4 text-sm text-[var(--color-text-dim)]">Current Episode: Live Transcript</div>
+          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-5 py-4 pb-24">
+            {segments.map((segment) => (
+              <article key={segment.id} className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm">
+                {segment.text}
+              </article>
+            ))}
+            {interimText && <article className="rounded-xl border border-dashed border-[var(--color-accent-blue)] px-4 py-3 text-sm text-[var(--color-text-dim)]">{interimText}</article>}
+          </div>
+
+          <form
+            className="absolute bottom-0 left-0 right-0 flex gap-2 border-t border-white/10 bg-[var(--color-card-bg)] p-3"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void pushFinalSegment(fallbackText);
+              setFallbackText('');
+            }}
+          >
+            <input
+              value={fallbackText}
+              onChange={(e) => setFallbackText(e.target.value)}
+              placeholder={supportsSpeech ? 'Fallback text input...' : 'Speech unsupported; type your transcript...'}
+              className="flex-1 rounded-lg border border-white/10 bg-transparent px-3 py-2 text-sm outline-none"
+            />
+            <button className="rounded-lg border border-white/20 px-3 py-2 text-sm">Submit</button>
+          </form>
+        </section>
+
+        <aside className="w-[340px] border-l border-white/10 bg-[var(--color-card-bg)]">
+          <div className="border-b border-white/10 px-5 py-4 text-sm text-[var(--color-text-dim)]">Live Crew Intelligence</div>
+          <div className="space-y-3 p-4">
+            {personaMeta.map((persona) => {
+              const response = latestSegment?.personaResponses?.[persona.key];
+              const active = Boolean(response);
+              return (
+                <div
+                  key={persona.key}
+                  className={`rounded-xl border p-3 transition ${active ? 'border-white/30 bg-white/10' : 'border-white/10 opacity-45 grayscale'}`}
+                >
+                  <div className="mb-2 flex items-center justify-between">
+                    <div className="flex items-center gap-2 text-sm">
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: persona.color }} />
+                      {persona.label}
+                    </div>
+                    {active && (
+                      <div className="flex items-end gap-1">
+                        {[0, 1, 2].map((i) => (
+                          <motion.span
+                            key={i}
+                            className="w-1 rounded bg-[var(--color-accent-blue)]"
+                            animate={{ height: [4, 14, 6] }}
+                            transition={{ duration: 0.9, repeat: Infinity, delay: i * 0.1 }}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <p className="text-sm text-[var(--color-text-dim)]">{response || 'Standing by.'}</p>
+                </div>
+              );
+            })}
+          </div>
+        </aside>
+      </main>
+
+      <footer className="flex h-[80px] items-center gap-3 border-t border-white/10 px-6">
+        <button className="rounded-full border border-white/20 px-4 py-2 text-sm">{isRecording ? <MicOff className="inline" size={14} /> : <Mic className="inline" size={14} />} Mute Host</button>
+        <button className="rounded-full border border-white/20 px-4 py-2 text-sm">AI Sensitivity: High</button>
+        <button className="rounded-full bg-red-500/90 px-4 py-2 text-sm">End Session</button>
+        <button className="rounded-full border border-white/20 px-4 py-2 text-sm"><Radio className="mr-1 inline" size={14} />Invite Crew Member</button>
+      </footer>
+    </div>
+  );
+}

--- a/cuecrew-ai/src/LandingPage.tsx
+++ b/cuecrew-ai/src/LandingPage.tsx
@@ -1,0 +1,78 @@
+import { motion } from 'motion/react';
+
+const personas = [
+  { name: 'Fact-checker', color: 'var(--color-tag-fact)' },
+  { name: 'Context Provider', color: 'var(--color-tag-context)' },
+  { name: 'Comedy Writer', color: 'var(--color-tag-joke)' },
+  { name: 'News Anchor', color: 'var(--color-tag-news)' },
+];
+
+function SineBars() {
+  return (
+    <div className="flex items-end gap-1">
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          className="w-1 rounded bg-[var(--color-accent-blue)]"
+          animate={{ height: [6, 18, 8, 14, 6] }}
+          transition={{ duration: 1, repeat: Infinity, delay: i * 0.12 }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default function LandingPage({ onLaunch }: { onLaunch: () => void }) {
+  return (
+    <div className="mx-auto min-h-screen max-w-6xl px-6 py-8">
+      <nav className="mb-16 flex items-center justify-between">
+        <h1 className="text-2xl" style={{ fontFamily: 'var(--font-serif)' }}>
+          Cue<span style={{ color: 'var(--color-accent-gold)' }}>crew</span>.ai
+        </h1>
+        <button onClick={onLaunch} className="rounded-full border border-white/20 px-5 py-2 text-sm hover:bg-white/10">
+          Try Demo
+        </button>
+      </nav>
+
+      <div className="grid items-center gap-10 md:grid-cols-2">
+        <section>
+          <span className="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-sm text-[var(--color-text-dim)]">
+            Your real-time AI production crew
+          </span>
+          <h2 className="mt-6 text-5xl leading-tight" style={{ fontFamily: 'var(--font-serif)' }}>
+            Never record <span style={{ color: 'var(--color-accent-gold)' }}>alone again</span>.
+          </h2>
+          <p className="mt-5 max-w-lg text-lg text-[var(--color-text-dim)]">
+            Cuecrew.ai listens to your live show and sends instant facts, context, punch-ups, and breaking updates.
+          </p>
+          <button
+            onClick={onLaunch}
+            className="mt-8 rounded-full bg-[var(--color-accent-blue)] px-6 py-3 font-medium text-black hover:opacity-90"
+          >
+            Launch Studio
+          </button>
+        </section>
+
+        <section className="rounded-3xl border border-white/10 bg-[var(--color-card-bg)] p-6">
+          <p className="mb-5 text-sm text-[var(--color-text-dim)]">Crew activity</p>
+          <div className="space-y-4">
+            {personas.map((persona) => (
+              <motion.div
+                key={persona.name}
+                className="flex items-center justify-between rounded-2xl border border-white/10 px-4 py-3"
+                animate={{ y: [0, -2, 0] }}
+                transition={{ duration: 2.2, repeat: Infinity }}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="h-3 w-3 rounded-full" style={{ backgroundColor: persona.color }} />
+                  <p>{persona.name}</p>
+                </div>
+                <SineBars />
+              </motion.div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/cuecrew-ai/src/gemini.ts
+++ b/cuecrew-ai/src/gemini.ts
@@ -1,0 +1,41 @@
+import { GoogleGenAI, Type } from '@google/genai';
+import type { PersonaResponses } from './types';
+
+const apiKey =
+  (typeof process !== 'undefined' && process.env?.GEMINI_API_KEY) ||
+  (import.meta as { env?: { GEMINI_API_KEY?: string } }).env?.GEMINI_API_KEY;
+
+const ai = apiKey ? new GoogleGenAI({ apiKey }) : null;
+
+export async function getPersonaResponses(transcript: string): Promise<PersonaResponses> {
+  if (!ai) {
+    return {};
+  }
+
+  const prompt = `You are a team of four AI personas assisting a podcast host in real-time. The host just said: '${transcript}'. If any of the personas have something highly relevant, interesting, or funny to add, provide their response. Keep responses very short (1-2 sentences max). If a persona has nothing useful to add, omit their field.`;
+
+  const response = await ai.models.generateContent({
+    model: 'gemini-3-flash-preview',
+    contents: prompt,
+    config: {
+      responseMimeType: 'application/json',
+      responseSchema: {
+        type: Type.OBJECT,
+        properties: {
+          factChecker: { type: Type.STRING },
+          contextProvider: { type: Type.STRING },
+          comedyWriter: { type: Type.STRING },
+          newsAnchor: { type: Type.STRING },
+        },
+      },
+    },
+  });
+
+  const text = response.text || '{}';
+
+  try {
+    return JSON.parse(text) as PersonaResponses;
+  } catch {
+    return {};
+  }
+}

--- a/cuecrew-ai/src/index.css
+++ b/cuecrew-ai/src/index.css
@@ -1,0 +1,29 @@
+@import "tailwindcss";
+
+@theme {
+  --color-bg-dark: #0a0a0c;
+  --color-card-bg: #141418;
+  --color-accent-blue: #40a9ff;
+  --color-accent-gold: #c9a063;
+  --color-text-main: #e1e1e6;
+  --color-text-dim: #8e8e93;
+  --color-border-color: rgba(255, 255, 255, 0.1);
+
+  --color-tag-fact: #ffd166;
+  --color-tag-news: #06d6a0;
+  --color-tag-joke: #ef476f;
+  --color-tag-context: #118ab2;
+
+  --font-serif: 'Georgia', serif;
+  --font-sans: 'Helvetica Neue', Arial, sans-serif;
+}
+
+body {
+  background-color: var(--color-bg-dark);
+  color: var(--color-text-main);
+  font-family: var(--font-sans);
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/cuecrew-ai/src/main.tsx
+++ b/cuecrew-ai/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/cuecrew-ai/src/types.ts
+++ b/cuecrew-ai/src/types.ts
@@ -1,0 +1,12 @@
+export type PersonaResponses = {
+  factChecker?: string;
+  contextProvider?: string;
+  comedyWriter?: string;
+  newsAnchor?: string;
+};
+
+export type TranscriptSegment = {
+  id: string;
+  text: string;
+  personaResponses?: PersonaResponses;
+};

--- a/cuecrew-ai/tsconfig.json
+++ b/cuecrew-ai/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client"],
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/cuecrew-ai/vite.config.ts
+++ b/cuecrew-ai/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
### Motivation
- Provide a small standalone Vite + React + TypeScript demo app implementing the Cuecrew.ai concept: a live studio that listens to a host and surfaces short, persona-driven AI responses in real time. 
- Deliver a sophisticated dark design system and two main views (Landing and Studio) so the UI/UX can be previewed and iterated on independently.

### Description
- Scaffolds a new `cuecrew-ai` app with Vite tooling files (`index.html`, `package.json`, `vite.config.ts`, `tsconfig.json`, `src/main.tsx`).
- Adds dark theme design tokens and base Tailwind v4 import in `src/index.css` implementing the requested color variables and fonts.
- Implements view routing via local state in `src/App.tsx` and the Landing UI in `src/LandingPage.tsx` with animated persona visualizer (using `motion/react`).
- Builds the Studio interface in `src/DemoApp.tsx` with header/footer controls, continuous browser `SpeechRecognition` handling (interim/final), transcript segment state, typed fallback input, persona cards, and animated activity bars.
- Integrates Gemini via `src/gemini.ts` using `@google/genai` and a JSON schema (`responseMimeType: 'application/json'`) to return typed persona responses, plus typed definitions in `src/types.ts`.
- Wire-up: final transcript segments trigger `getPersonaResponses`, and returned persona fields update/highlight the latest segment’s persona cards in the intelligence rail.

### Testing
- Ran `npm install` in the `cuecrew-ai` directory to validate dependencies, but `npm install` failed due to a registry access policy (`403 Forbidden` for `@google/genai`), so build and runtime verification could not be completed in this environment.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06413070c83289a9bd31ea1541ad3)