### PR TITLE
Refine Consendus console simulation stability and timestamps

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -234,9 +234,9 @@ export default function Consendus() {
   const [activeChannel, setActiveChannel] = useState(channels[0])
   const [messages, setMessages] = useState(initialMessages)
   const [simulating, setSimulating] = useState(false)
-  const [typingAgent, setTypingAgent] = useState('')
   const [typingAgents, setTypingAgents] = useState([])
   const chatScrollRef = useRef(null)
+  const simulationTimersRef = useRef([])
 
   const tasksByState = useMemo(
     () =>
@@ -257,6 +257,25 @@ export default function Consendus() {
       behavior: 'smooth',
     })
   }, [messages, typingAgents, activeChannel, activeTab])
+
+  useEffect(
+    () => () => {
+      simulationTimersRef.current.forEach((timerId) => clearTimeout(timerId))
+      simulationTimersRef.current = []
+    },
+    []
+  )
+
+  const scheduleSimulation = (callback, delay) => {
+    const timerId = setTimeout(callback, delay)
+    simulationTimersRef.current.push(timerId)
+  }
+
+  const formatSimulationTime = (offset = 0) => {
+    const now = new Date()
+    now.setSeconds(now.getSeconds() + offset)
+    return now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })
+  }
 
   const handleAccessConsole = () => {
     setIsEnteringConsole(true)
@@ -307,28 +326,28 @@ export default function Consendus() {
     const generated = pool.sort(() => Math.random() - 0.5).slice(0, targetCount)
 
     setSimulating(true)
-    setTypingAgent('')
     setTypingAgents(generated.map((message) => message.author))
 
     generated.forEach((message, index) => {
-      setTimeout(() => {
+      scheduleSimulation(() => {
         setTypingAgents((prev) => (prev.includes(message.author) ? prev : [...prev, message.author]))
       }, index * 700 + 260)
 
-      setTimeout(() => {
+      scheduleSimulation(() => {
         setMessages((prev) => [
           ...prev,
           {
             ...message,
             id: prev.length + 1,
-            time: `09:${50 + index}`,
+            time: formatSimulationTime(index * 60),
           },
         ])
         setTypingAgents((prev) => prev.filter((agent) => agent !== message.author))
 
         if (index === generated.length - 1) {
-          setTimeout(() => {
+          scheduleSimulation(() => {
             setSimulating(false)
+            simulationTimersRef.current = []
           }, 260)
         }
       }, (index + 1) * 700)


### PR DESCRIPTION
### Motivation
- Prevent stale/dangling timeouts and make simulated chat timestamps more realistic in the Consendus Console.
- Simplify typing state management for the Comms simulation to reduce unnecessary state and potential bugs.

### Description
- Removed an unused `typingAgent` state and kept `typingAgents` for multi-agent typing indicators in `pages/consendus.js`.
- Added `simulationTimersRef` (a `useRef` array) and an unmount cleanup `useEffect` to clear any queued `setTimeout` timers.
- Introduced `scheduleSimulation(callback, delay)` to centralize scheduling and tracking of simulation timers and `formatSimulationTime(offset)` to produce HH:MM timestamps for simulated messages.
- Updated `appendSimulatedMessages` to use the scheduler/formatter and reset the timer tracking when the simulation completes; changes are scoped to `pages/consendus.js` only.

### Testing
- Ran `npm run build`; the Consendus changes compiled, but the build failed due to unrelated syntax errors in `pages/lumiere.js` and `pages/mealcycle.js` (these errors are pre-existing and outside the scope of this change).
- Verified the repository status after the change (no outstanding modified files beyond the intended `pages/consendus.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10f0b20e483289909313bb16ce3e5)