### PR TITLE
Consendus: Progressive chat typing indicators and fleet status legend

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -306,7 +306,7 @@ export default function Consendus() {
     const generated = pool.sort(() => Math.random() - 0.5).slice(0, targetCount)
 
     setSimulating(true)
-    setTypingAgents(generated.map((message) => message.author))
+    setTypingAgents([])
 
     generated.forEach((message, index) => {
       setTimeout(() => {
@@ -545,6 +545,20 @@ export default function Consendus() {
 
     return (
       <ViewContainer key={activeTab}>
+        <section className="mb-4 flex flex-wrap items-center gap-3 text-xs text-slate-300">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-slate-800/70 px-3 py-1">
+            <span className="h-2 w-2 rounded-full bg-emerald-400" />
+            Idle
+          </span>
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-slate-800/70 px-3 py-1">
+            <span className="h-2 w-2 rounded-full bg-amber-400" />
+            Busy
+          </span>
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-slate-800/70 px-3 py-1">
+            <span className="h-2 w-2 rounded-full bg-red-500" />
+            Error
+          </span>
+        </section>
         <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {agents.map((agent) => (
             <article key={agent.name} className="rounded-xl border border-white/10 bg-slate-800/70 p-4 backdrop-blur">


### PR DESCRIPTION
### Motivation
- Improve the simulated chat UX so typing indicators appear progressively with subtle delays instead of showing all at once.  
- Make the Agent Fleet view immediately understandable by exposing a small status legend for Idle/Busy/Error states.

### Description
- Updated `pages/consendus.js` to initialize `typingAgents` as an empty array in `appendSimulatedMessages` so typing indicators are added per-message with staggered timeouts to create progressive typing effects.  
- Added a compact status legend above the Agent Fleet grid in `pages/consendus.js` showing Idle/Busy/Error color chips to clarify the meaning of the status dots.  
- Kept styling consistent with the app’s dark theme and existing animations by reusing existing Tailwind classes and layout patterns.

### Testing
- Ran `npm run build`; the build failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`), and the failure is not caused by changes in `pages/consendus.js`.  
- Ran `npx next lint --file pages/consendus.js`; the linter process started and displayed the ESLint configuration prompt (no lint errors were reported for the modified file before the interactive prompt).  
- No other automated tests are configured or were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e228a02c6883289aa25c4df02ee959)