### PR TITLE
Cuecrew.ai: Landing + Live Studio UI, Gemini wiring, and build fixes

### DIFF
--- a/cuecrew-ai/src/DemoApp.tsx
+++ b/cuecrew-ai/src/DemoApp.tsx
@@ -6,12 +6,26 @@ import type { PersonaResponses, TranscriptSegment } from './types';
 
 type Props = { onBack: () => void };
 
-type SpeechRecognitionType = typeof window.SpeechRecognition;
+type SpeechRecognitionResultItem = { transcript: string };
+type SpeechRecognitionResultLike = { isFinal: boolean; 0: SpeechRecognitionResultItem };
+type SpeechRecognitionEventLike = { resultIndex: number; results: ArrayLike<SpeechRecognitionResultLike> };
+
+type SpeechRecognitionLike = {
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onerror: (() => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+};
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
 
 declare global {
   interface Window {
-    webkitSpeechRecognition: SpeechRecognitionType;
-    SpeechRecognition: SpeechRecognitionType;
+    webkitSpeechRecognition?: SpeechRecognitionCtor;
+    SpeechRecognition?: SpeechRecognitionCtor;
   }
 }
 
@@ -28,9 +42,9 @@ export default function DemoApp({ onBack }: Props) {
   const [isRecording, setIsRecording] = useState(false);
   const [fallbackText, setFallbackText] = useState('');
   const [supportsSpeech, setSupportsSpeech] = useState(true);
-  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
 
-  const latestSegment = useMemo(() => segments.at(-1), [segments]);
+  const latestSegment = useMemo(() => segments[segments.length - 1], [segments]);
 
   useEffect(() => {
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
@@ -43,14 +57,14 @@ export default function DemoApp({ onBack }: Props) {
     recognition.continuous = true;
     recognition.interimResults = true;
 
-    recognition.onresult = (event) => {
+    recognition.onresult = (event: SpeechRecognitionEventLike) => {
       let interim = '';
 
       for (let i = event.resultIndex; i < event.results.length; i += 1) {
         const transcript = event.results[i][0].transcript.trim();
 
         if (event.results[i].isFinal) {
-          pushFinalSegment(transcript);
+          void pushFinalSegment(transcript);
         } else {
           interim += `${transcript} `;
         }
@@ -68,7 +82,7 @@ export default function DemoApp({ onBack }: Props) {
   }, [isRecording]);
 
   const pushFinalSegment = async (text: string) => {
-    if (!text) return;
+    if (!text.trim()) return;
 
     const id = crypto.randomUUID();
     setSegments((prev) => [...prev, { id, text }]);
@@ -102,11 +116,19 @@ export default function DemoApp({ onBack }: Props) {
             Cue<span style={{ color: 'var(--color-accent-gold)' }}>crew</span>.ai
           </h1>
           <span className="ml-2 flex items-center gap-2 text-sm text-red-400">
-            <motion.span className="h-2 w-2 rounded-full bg-red-500" animate={{ opacity: [1, 0.3, 1] }} transition={{ duration: 1.2, repeat: Infinity }} />
+            <motion.span
+              className="h-2 w-2 rounded-full bg-red-500"
+              animate={{ opacity: [1, 0.3, 1] }}
+              transition={{ duration: 1.2, repeat: Infinity }}
+            />
             Live Studio
           </span>
         </div>
-        <button onClick={toggleRecording} className="rounded-full bg-[var(--color-accent-blue)] px-4 py-2 text-black">
+        <button
+          onClick={toggleRecording}
+          disabled={!supportsSpeech}
+          className="rounded-full bg-[var(--color-accent-blue)] px-4 py-2 text-black disabled:cursor-not-allowed disabled:opacity-40"
+        >
           {isRecording ? 'Stop Recording' : 'Start Recording'}
         </button>
       </header>
@@ -115,12 +137,21 @@ export default function DemoApp({ onBack }: Props) {
         <section className="relative flex min-h-0 flex-1 flex-col border-r border-white/10">
           <div className="border-b border-white/10 px-5 py-4 text-sm text-[var(--color-text-dim)]">Current Episode: Live Transcript</div>
           <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-5 py-4 pb-24">
+            {segments.length === 0 && (
+              <article className="rounded-xl border border-dashed border-white/20 px-4 py-3 text-sm text-[var(--color-text-dim)]">
+                Start recording or type below to begin your live transcript.
+              </article>
+            )}
             {segments.map((segment) => (
               <article key={segment.id} className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm">
                 {segment.text}
               </article>
             ))}
-            {interimText && <article className="rounded-xl border border-dashed border-[var(--color-accent-blue)] px-4 py-3 text-sm text-[var(--color-text-dim)]">{interimText}</article>}
+            {interimText && (
+              <article className="rounded-xl border border-dashed border-[var(--color-accent-blue)] px-4 py-3 text-sm text-[var(--color-text-dim)]">
+                {interimText}
+              </article>
+            )}
           </div>
 
           <form
@@ -137,7 +168,9 @@ export default function DemoApp({ onBack }: Props) {
               placeholder={supportsSpeech ? 'Fallback text input...' : 'Speech unsupported; type your transcript...'}
               className="flex-1 rounded-lg border border-white/10 bg-transparent px-3 py-2 text-sm outline-none"
             />
-            <button className="rounded-lg border border-white/20 px-3 py-2 text-sm">Submit</button>
+            <button disabled={!fallbackText.trim()} className="rounded-lg border border-white/20 px-3 py-2 text-sm disabled:opacity-50">
+              Submit
+            </button>
           </form>
         </section>
 
@@ -179,10 +212,15 @@ export default function DemoApp({ onBack }: Props) {
       </main>
 
       <footer className="flex h-[80px] items-center gap-3 border-t border-white/10 px-6">
-        <button className="rounded-full border border-white/20 px-4 py-2 text-sm">{isRecording ? <MicOff className="inline" size={14} /> : <Mic className="inline" size={14} />} Mute Host</button>
+        <button className="rounded-full border border-white/20 px-4 py-2 text-sm">
+          {isRecording ? <MicOff className="inline" size={14} /> : <Mic className="inline" size={14} />} Mute Host
+        </button>
         <button className="rounded-full border border-white/20 px-4 py-2 text-sm">AI Sensitivity: High</button>
         <button className="rounded-full bg-red-500/90 px-4 py-2 text-sm">End Session</button>
-        <button className="rounded-full border border-white/20 px-4 py-2 text-sm"><Radio className="mr-1 inline" size={14} />Invite Crew Member</button>
+        <button className="rounded-full border border-white/20 px-4 py-2 text-sm">
+          <Radio className="mr-1 inline" size={14} />
+          Invite Crew Member
+        </button>
       </footer>
     </div>
   );

--- a/cuecrew-ai/src/LandingPage.tsx
+++ b/cuecrew-ai/src/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'motion/react';
+import { Sparkles } from 'lucide-react';
 
 const personas = [
   { name: 'Fact-checker', color: 'var(--color-tag-fact)' },
@@ -36,14 +37,16 @@ export default function LandingPage({ onLaunch }: { onLaunch: () => void }) {
 
       <div className="grid items-center gap-10 md:grid-cols-2">
         <section>
-          <span className="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-sm text-[var(--color-text-dim)]">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-sm text-[var(--color-text-dim)]">
+            <Sparkles size={14} />
             Your real-time AI production crew
           </span>
           <h2 className="mt-6 text-5xl leading-tight" style={{ fontFamily: 'var(--font-serif)' }}>
             Never record <span style={{ color: 'var(--color-accent-gold)' }}>alone again</span>.
           </h2>
           <p className="mt-5 max-w-lg text-lg text-[var(--color-text-dim)]">
-            Cuecrew.ai listens to your live show and sends instant facts, context, punch-ups, and breaking updates.
+            Cuecrew.ai listens to your live show and sends instant facts, context, punch-ups, and breaking updates while
+            you stay focused on hosting.
           </p>
           <button
             onClick={onLaunch}
@@ -53,7 +56,7 @@ export default function LandingPage({ onLaunch }: { onLaunch: () => void }) {
           </button>
         </section>
 
-        <section className="rounded-3xl border border-white/10 bg-[var(--color-card-bg)] p-6">
+        <section className="rounded-3xl border border-white/10 bg-[var(--color-card-bg)] p-6 shadow-2xl shadow-black/30">
           <p className="mb-5 text-sm text-[var(--color-text-dim)]">Crew activity</p>
           <div className="space-y-4">
             {personas.map((persona) => (

--- a/cuecrew-ai/src/gemini.ts
+++ b/cuecrew-ai/src/gemini.ts
@@ -2,8 +2,9 @@ import { GoogleGenAI, Type } from '@google/genai';
 import type { PersonaResponses } from './types';
 
 const apiKey =
-  (typeof process !== 'undefined' && process.env?.GEMINI_API_KEY) ||
-  (import.meta as { env?: { GEMINI_API_KEY?: string } }).env?.GEMINI_API_KEY;
+  (globalThis as { process?: { env?: { GEMINI_API_KEY?: string } } }).process?.env?.GEMINI_API_KEY ||
+  (import.meta as { env?: { GEMINI_API_KEY?: string; VITE_GEMINI_API_KEY?: string } }).env?.GEMINI_API_KEY ||
+  (import.meta as { env?: { GEMINI_API_KEY?: string; VITE_GEMINI_API_KEY?: string } }).env?.VITE_GEMINI_API_KEY;
 
 const ai = apiKey ? new GoogleGenAI({ apiKey }) : null;
 

--- a/cuecrew-ai/tsconfig.json
+++ b/cuecrew-ai/tsconfig.json
@@ -5,8 +5,13 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
-    "types": ["vite/client"],
-    "noEmit": true
+    "types": [
+      "vite/client"
+    ],
+    "noEmit": true,
+    "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Implement a polished Cuecrew.ai demo (landing + live studio) that follows the requested dark theme, persona visualizer, and live AI persona feedback flow. 
- Ensure the frontend builds cleanly with the `@google/genai` SDK and TypeScript in a Vite environment.

### Description
- Landing: enhanced hero pill with `Sparkles`, serif/gold brand treatment, copy tweak, and a shadowed crew activity panel with animated sine bars (`cuecrew-ai/src/LandingPage.tsx`).
- Studio: built the live studio layout including header controls, transcript stream (interim/final), fallback input, persona cards with active/dim states and animations, disabled/empty states, and minor UI refinements (`cuecrew-ai/src/DemoApp.tsx`).
- Speech/Types: introduced a lightweight `SpeechRecognitionLike` type surface, replaced `Array.at` usage with `segments[segments.length - 1]`, tightened event typing, and added defensive `trim()` checks before pushing segments (`cuecrew-ai/src/DemoApp.tsx`).
- Gemini: improved API key resolution to prefer runtime `process.env` and Vite `import.meta.env` fallbacks, and keep the JSON schema/constrained output via `gemini-3-flash-preview` (`cuecrew-ai/src/gemini.ts`).
- Build: enabled `skipLibCheck` in `tsconfig.json` to avoid SDK ambient-type conflicts during frontend builds (`cuecrew-ai/tsconfig.json`).

### Testing
- Ran `npm run build` in `cuecrew-ai/` and the final build completed successfully after the TypeScript/type adjustments. 
- An initial `tsc` failure due to Node typings was observed and resolved by the typing fixes and `skipLibCheck`, after which the production build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d17d01108328b51816c1285eb8fd)