### PR TITLE
Improve Consendus console: structured terminal logs, staged typing, and fade-in messages

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -73,6 +73,16 @@ const analytics = [
 
 const channels = ['#migration-api-v2', '#security-audit', '#platform-rollout', '#compliance-vote']
 
+const systemEvents = [
+  { level: 'INFO', text: 'Agent-2 connected to semantic bus (latency 18ms)' },
+  { level: 'INFO', text: 'Consensus quorum initialized for task-3' },
+  { level: 'WARN', text: 'High latency detected on shard eu-west-1' },
+  { level: 'INFO', text: 'Guardian Rails policy patch applied by Sentry-Sec' },
+  { level: 'INFO', text: 'Token limiter adjusted (window=10s burst=128)' },
+  { level: 'SUCCESS', text: 'Deployment approved after 3/3 votes' },
+  { level: 'INFO', text: 'Heartbeat stream stable (24 active agents)' },
+]
+
 const initialMessages = [
   {
     id: 1,
@@ -326,7 +336,7 @@ export default function Consendus() {
     const generated = pool.sort(() => Math.random() - 0.5).slice(0, targetCount)
 
     setSimulating(true)
-    setTypingAgents(generated.map((message) => message.author))
+    setTypingAgents([])
 
     generated.forEach((message, index) => {
       scheduleSimulation(() => {
@@ -347,7 +357,6 @@ export default function Consendus() {
         if (index === generated.length - 1) {
           scheduleSimulation(() => {
             setSimulating(false)
-            simulationTimersRef.current = []
           }, 260)
         }
       }, (index + 1) * 700)
@@ -427,13 +436,22 @@ export default function Consendus() {
                 className="h-[280px] overflow-auto rounded-lg border border-white/10 bg-slate-950 p-3 text-xs leading-6 text-slate-300"
                 style={{ fontFamily: 'JetBrains Mono, monospace' }}
               >
-                <p>[INFO] Agent-2 connected to semantic bus (latency 18ms)</p>
-                <p>[INFO] Consensus quorum initialized for task-3</p>
-                <p>[WARN] High latency detected on shard eu-west-1</p>
-                <p>[INFO] Guardian Rails policy patch applied by Sentry-Sec</p>
-                <p>[INFO] Token limiter adjusted (window=10s burst=128)</p>
-                <p>[SUCCESS] Deployment approved after 3/3 votes</p>
-                <p>[INFO] Heartbeat stream stable (24 active agents)</p>
+                {systemEvents.map((event, idx) => (
+                  <p key={`${event.level}-${idx}`} className={event.level === 'WARN' ? 'text-amber-200' : ''}>
+                    <span
+                      className={
+                        event.level === 'SUCCESS'
+                          ? 'text-emerald-300'
+                          : event.level === 'WARN'
+                            ? 'text-amber-300'
+                            : 'text-indigo-200'
+                      }
+                    >
+                      [{event.level}]
+                    </span>{' '}
+                    {event.text}
+                  </p>
+                ))}
               </div>
             </div>
           </section>
@@ -486,7 +504,7 @@ export default function Consendus() {
                 {channelMessages.map((message) => (
                   <article
                     key={message.id}
-                    className={`rounded-xl border p-3 ${
+                    className={`animate-[fadeIn_0.22s_ease] rounded-xl border p-3 ${
                       message.type === 'alert'
                         ? 'border-amber-400/30 bg-amber-500/10'
                         : 'border-white/10 bg-slate-900/70'
@@ -748,6 +766,18 @@ await swarm.deploy('migration-api-v2')`}
           </div>
         )}
       </div>
+      <style jsx global>{`
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+            transform: translateY(6px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+      `}</style>
     </>
   )
 }


### PR DESCRIPTION
### Motivation
- Polish the Consendus console UX to feel more like a developer control plane by improving terminal log rendering and visual affordances. 
- Make chat simulation behavior match the requested simulated typing delays so agents appear to type in sequence. 
- Add subtle message animations to smooth transitions when new chat events appear.

### Description
- Introduced a `systemEvents` mock array and replaced hardcoded terminal lines with semantic rendering that colors levels (`INFO`, `WARN`, `SUCCESS`) in `pages/consendus.js`.
- Updated the comms simulation flow to initialize `typingAgents` to an empty array and stage typing indicators via the existing `scheduleSimulation` calls so agents appear sequentially before each message is appended.
- Added a global `@keyframes fadeIn` and applied an `animate-[fadeIn_0.22s_ease]` class to message cards to provide a subtle fade/slide effect for new messages.
- Kept timer cleanup in the existing unmount effect and removed the redundant clearing of `simulationTimersRef.current` at the end of the simulation sequence.

### Testing
- Ran `npm run build` (Next.js build) which failed due to pre-existing syntax errors in unrelated pages (`pages/lumiere.js` and `pages/mealcycle.js`), so the build error is unrelated to the `pages/consendus.js` changes.
- Verified the patch was committed (`pages/consendus.js` updated) and changes are ready for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e628df86d8832894b8ac4da1e63c44)