### PR TITLE
Enhance Cuecrew demo persona activity states

### DIFF
--- a/cuecrew-ai/src/DemoApp.tsx
+++ b/cuecrew-ai/src/DemoApp.tsx
@@ -40,6 +40,7 @@ export default function DemoApp({ onBack }: Props) {
   const [segments, setSegments] = useState<TranscriptSegment[]>([]);
   const [interimText, setInterimText] = useState('');
   const [isRecording, setIsRecording] = useState(false);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [fallbackText, setFallbackText] = useState('');
   const [supportsSpeech, setSupportsSpeech] = useState(true);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
@@ -87,9 +88,14 @@ export default function DemoApp({ onBack }: Props) {
     const id = crypto.randomUUID();
     setSegments((prev) => [...prev, { id, text }]);
     setInterimText('');
+    setIsAnalyzing(true);
 
-    const personaResponses = await getPersonaResponses(text);
-    setSegments((prev) => prev.map((seg) => (seg.id === id ? { ...seg, personaResponses } : seg)));
+    try {
+      const personaResponses = await getPersonaResponses(text);
+      setSegments((prev) => prev.map((seg) => (seg.id === id ? { ...seg, personaResponses } : seg)));
+    } finally {
+      setIsAnalyzing(false);
+    }
   };
 
   const toggleRecording = () => {
@@ -175,15 +181,21 @@ export default function DemoApp({ onBack }: Props) {
         </section>
 
         <aside className="w-[340px] border-l border-white/10 bg-[var(--color-card-bg)]">
-          <div className="border-b border-white/10 px-5 py-4 text-sm text-[var(--color-text-dim)]">Live Crew Intelligence</div>
+          <div className="flex items-center justify-between border-b border-white/10 px-5 py-4 text-sm text-[var(--color-text-dim)]">
+            <span>Live Crew Intelligence</span>
+            {isAnalyzing && <span className="text-xs text-[var(--color-accent-blue)]">Analyzing…</span>}
+          </div>
           <div className="space-y-3 p-4">
             {personaMeta.map((persona) => {
               const response = latestSegment?.personaResponses?.[persona.key];
               const active = Boolean(response);
+              const pending = isAnalyzing && latestSegment && !response;
               return (
                 <div
                   key={persona.key}
-                  className={`rounded-xl border p-3 transition ${active ? 'border-white/30 bg-white/10' : 'border-white/10 opacity-45 grayscale'}`}
+                  className={`rounded-xl border p-3 transition ${
+                    active ? 'border-white/30 bg-white/10' : pending ? 'border-blue-300/40 bg-blue-300/5' : 'border-white/10 opacity-45 grayscale'
+                  }`}
                 >
                   <div className="mb-2 flex items-center justify-between">
                     <div className="flex items-center gap-2 text-sm">
@@ -203,7 +215,7 @@ export default function DemoApp({ onBack }: Props) {
                       </div>
                     )}
                   </div>
-                  <p className="text-sm text-[var(--color-text-dim)]">{response || 'Standing by.'}</p>
+                  <p className="text-sm text-[var(--color-text-dim)]">{response || (pending ? 'Listening for a strong cue…' : 'Standing by.')}</p>
                 </div>
               );
             })}

--- a/cuecrew-ai/src/LandingPage.tsx
+++ b/cuecrew-ai/src/LandingPage.tsx
@@ -2,10 +2,10 @@ import { motion } from 'motion/react';
 import { Sparkles } from 'lucide-react';
 
 const personas = [
-  { name: 'Fact-checker', color: 'var(--color-tag-fact)' },
-  { name: 'Context Provider', color: 'var(--color-tag-context)' },
-  { name: 'Comedy Writer', color: 'var(--color-tag-joke)' },
-  { name: 'News Anchor', color: 'var(--color-tag-news)' },
+  { name: 'Fact-checker', color: 'var(--color-tag-fact)', sample: 'Claim check ready' },
+  { name: 'Context Provider', color: 'var(--color-tag-context)', sample: 'Timeline surfaced' },
+  { name: 'Comedy Writer', color: 'var(--color-tag-joke)', sample: 'Punchline queued' },
+  { name: 'News Anchor', color: 'var(--color-tag-news)', sample: 'Breaking update found' },
 ];
 
 function SineBars() {
@@ -67,8 +67,13 @@ export default function LandingPage({ onLaunch }: { onLaunch: () => void }) {
                 transition={{ duration: 2.2, repeat: Infinity }}
               >
                 <div className="flex items-center gap-3">
-                  <span className="h-3 w-3 rounded-full" style={{ backgroundColor: persona.color }} />
-                  <p>{persona.name}</p>
+                  <span className="rounded-full px-2 py-0.5 text-xs font-medium text-black" style={{ backgroundColor: persona.color }}>
+                    LIVE
+                  </span>
+                  <div>
+                    <p>{persona.name}</p>
+                    <p className="text-xs text-[var(--color-text-dim)]">{persona.sample}</p>
+                  </div>
                 </div>
                 <SineBars />
               </motion.div>


### PR DESCRIPTION
### Motivation

- Improve the demo's affordance of “real-time crew” behavior by surfacing more explicit live activity on the landing visualizer and clearer analysis state in the Studio.

### Description

- Add persona sample labels and a colored `LIVE` badge to the landing visualizer to better represent each AI persona's current activity (`cuecrew-ai/src/LandingPage.tsx`).
- Introduce `isAnalyzing` state in the Studio to track when Gemini responses are being fetched and show an `Analyzing…` indicator in the right rail (`cuecrew-ai/src/DemoApp.tsx`).
- Update persona card rendering in the Studio to visually distinguish three states: active (has response), pending (analysis in progress), and idle, and adjust the card copy to show `Listening for a strong cue…` while pending (`cuecrew-ai/src/DemoApp.tsx`).
- Keep existing sine-wave/animation treatments while applying subtle color/opacity changes for pending vs active vs idle states.

### Testing

- Ran `npm run build` inside the `cuecrew-ai` package which completed successfully (TypeScript build + Vite production build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb9ec72d8832898e4638bea755dcd)