### PR TITLE
Polish Consendus console animations and chat markdown rendering

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -181,7 +181,7 @@ const statusColors = {
 const taskStates = ['Pending', 'In Progress', 'Needs Consensus', 'Completed']
 
 function ViewContainer({ children }) {
-  return <section className="animate-[fadeIn_.32s_ease]">{children}</section>
+  return <section style={{ animation: 'fadeIn 0.32s ease' }}>{children}</section>
 }
 
 function MessageBody({ message }) {
@@ -223,6 +223,16 @@ function MessageBody({ message }) {
   }
 
   if (message.type === 'markdown') {
+    return (
+      <div className="prose prose-invert max-w-none prose-p:my-1 prose-pre:my-2">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+          {message.content}
+        </ReactMarkdown>
+      </div>
+    )
+  }
+
+  if (message.type === 'text') {
     return (
       <div className="prose prose-invert max-w-none prose-p:my-1 prose-pre:my-2">
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
@@ -785,13 +795,37 @@ await swarm.deploy('migration-api-v2')`}
                 </button>
               </header>
 
-              <div className={tabVisible ? 'opacity-100 transition-opacity duration-200' : 'opacity-0 transition-opacity duration-150'}>
-                {renderTab()}
-              </div>
+                  <div
+                    className={tabVisible ? 'opacity-100 transition-opacity duration-200' : 'opacity-0 transition-opacity duration-150'}
+                    style={tabVisible ? { animation: 'fadeUp 0.24s ease' } : undefined}
+                  >
+                    {renderTab()}
+                  </div>
             </main>
           </div>
         )}
       </div>
+      <style jsx global>{`
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
+        }
+
+        @keyframes fadeUp {
+          from {
+            opacity: 0;
+            transform: translateY(6px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+      `}</style>
     </>
   )
 }


### PR DESCRIPTION
### Motivation
- Ensure view/tab transitions animate reliably without depending on undefined utility tokens, improving perceived polish.
- Make plain `text` chat messages render with the same inline/markdown formatting as `markdown` messages for consistent presentation.

### Description
- Replace the Tailwind-derived animation token in `ViewContainer` with an explicit inline `animation: 'fadeIn 0.32s ease'` style to guarantee the fade effect. 
- Add global `@keyframes` for `fadeIn` and `fadeUp` and apply `fadeUp` to tab content so tab visibility changes have a subtle upward fade animation. 
- Render messages with `type === 'text'` through `ReactMarkdown` (using the existing `markdownComponents`) so inline formatting and code spans display consistently with `markdown` messages. 
- Minor JSX placement/formatting adjustments in `pages/consendus.js` to integrate the above changes.

### Testing
- Ran `npm run build`, which triggered Next.js build checks and reported font optimization warnings and then failed due to pre-existing syntax errors in unrelated pages (`pages/lumiere.js` and `pages/mealcycle.js`), so the build did not succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac89b76208328a2f2fd92ef387299)