### PR TITLE
Refine Cuecrew landing visualizer and studio persona highlighting

### DIFF
--- a/cuecrew-ai/src/DemoApp.tsx
+++ b/cuecrew-ai/src/DemoApp.tsx
@@ -189,13 +189,10 @@ export default function DemoApp({ onBack }: Props) {
             {personaMeta.map((persona) => {
               const response = latestSegment?.personaResponses?.[persona.key];
               const active = Boolean(response);
-              const pending = isAnalyzing && latestSegment && !response;
               return (
                 <div
                   key={persona.key}
-                  className={`rounded-xl border p-3 transition ${
-                    active ? 'border-white/30 bg-white/10' : pending ? 'border-blue-300/40 bg-blue-300/5' : 'border-white/10 opacity-45 grayscale'
-                  }`}
+                  className={`rounded-xl border p-3 transition ${active ? 'border-white/30 bg-white/10' : 'border-white/10 opacity-45 grayscale'}`}
                 >
                   <div className="mb-2 flex items-center justify-between">
                     <div className="flex items-center gap-2 text-sm">
@@ -215,7 +212,7 @@ export default function DemoApp({ onBack }: Props) {
                       </div>
                     )}
                   </div>
-                  <p className="text-sm text-[var(--color-text-dim)]">{response || (pending ? 'Listening for a strong cue…' : 'Standing by.')}</p>
+                  <p className="text-sm text-[var(--color-text-dim)]">{response || 'Standing by.'}</p>
                 </div>
               );
             })}

--- a/cuecrew-ai/src/LandingPage.tsx
+++ b/cuecrew-ai/src/LandingPage.tsx
@@ -58,24 +58,22 @@ export default function LandingPage({ onLaunch }: { onLaunch: () => void }) {
 
         <section className="rounded-3xl border border-white/10 bg-[var(--color-card-bg)] p-6 shadow-2xl shadow-black/30">
           <p className="mb-5 text-sm text-[var(--color-text-dim)]">Crew activity</p>
-          <div className="space-y-4">
-            {personas.map((persona) => (
+          <div className="grid grid-cols-2 gap-4">
+            {personas.map((persona, index) => (
               <motion.div
                 key={persona.name}
-                className="flex items-center justify-between rounded-2xl border border-white/10 px-4 py-3"
-                animate={{ y: [0, -2, 0] }}
-                transition={{ duration: 2.2, repeat: Infinity }}
+                className="flex min-h-[130px] flex-col justify-between rounded-3xl border border-white/10 bg-white/[0.03] p-4"
+                animate={{ y: [0, -3, 0], scale: [1, 1.01, 1] }}
+                transition={{ duration: 2.4, repeat: Infinity, delay: index * 0.12 }}
               >
-                <div className="flex items-center gap-3">
-                  <span className="rounded-full px-2 py-0.5 text-xs font-medium text-black" style={{ backgroundColor: persona.color }}>
-                    LIVE
-                  </span>
+                <div className="mb-2 h-11 w-11 rounded-full" style={{ background: `radial-gradient(circle at 30% 30%, ${persona.color}, #0a0a0c)` }} />
+                <div className="flex items-center justify-between gap-3">
                   <div>
-                    <p>{persona.name}</p>
+                    <p className="text-sm">{persona.name}</p>
                     <p className="text-xs text-[var(--color-text-dim)]">{persona.sample}</p>
                   </div>
+                  <SineBars />
                 </div>
-                <SineBars />
               </motion.div>
             ))}
           </div>


### PR DESCRIPTION
### Motivation
- Improve the LandingPage visual mock to better match the requested polished demo style with clearer persona bubbles and animated activity indicators.
- Make the Studio's Live Crew Intelligence behavior deterministic by only highlighting personas when they produced a response for the latest transcript segment.
- Simplify the UI state for pending/standby so the intelligence panel is less noisy while analyzing.

### Description
- Updated the landing visualizer in `cuecrew-ai/src/LandingPage.tsx` to render persona bubble cards in a 2x2 grid with per-persona radial color treatments and staggered motion animation timings.
- Reworked the persona card layout to use larger rounded cards, compact waveform `SineBars`, and subtle scale/translate animations for a refined look.
- Adjusted studio persona behavior in `cuecrew-ai/src/DemoApp.tsx` so cards are highlighted only when the **latest** transcript segment contains that persona's response and otherwise remain dimmed (removed the separate `pending` styling and conditional message).
- Cleaned up copy for the persona cards so inactive cards show a single `Standing by.` message and active cards display the response and an animated 3-bar waveform.

### Testing
- Built the demo app with `cd cuecrew-ai && npm run build`, which completed successfully (Vite produced a production build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0bbf17508328930ba0d60f82c9fe)