### PR TITLE
Refine Consendus comms simulation behavior

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -304,7 +304,10 @@ export default function Consendus() {
   )
 
   const scheduleSimulation = (callback, delay) => {
-    const timerId = setTimeout(callback, delay)
+    const timerId = setTimeout(() => {
+      callback()
+      simulationTimersRef.current = simulationTimersRef.current.filter((id) => id !== timerId)
+    }, delay)
     simulationTimersRef.current.push(timerId)
   }
 
@@ -365,8 +368,9 @@ export default function Consendus() {
         content: 'Executed AI action: quorum lock engaged while waiting for final validator vote.',
       },
     ]
+    const uniquePool = pool.filter((message, index, source) => source.findIndex((item) => item.author === message.author) === index)
     const targetCount = Math.random() > 0.5 ? 3 : 2
-    const generated = pool.sort(() => Math.random() - 0.5).slice(0, targetCount)
+    const generated = uniquePool.sort(() => Math.random() - 0.5).slice(0, targetCount)
 
     setSimulating(true)
     setTypingAgents([])


### PR DESCRIPTION
### Motivation
- Prevent accumulation of stale timer IDs and make the simulated chat activity more realistic by avoiding multiple messages from the same agent in a single simulation run.
- Improve UX of the `Comms` view by ensuring typing indicators and message emissions are robust across repeated simulations.
- Keep the existing staged typing/message delays while removing edge cases that caused duplicate-author bursts.

### Description
- Updated the scheduler helper `scheduleSimulation` so each timeout removes its own ID from `simulationTimersRef` when it runs to prevent stale timer lists (modified `pages/consendus.js`).
- Ensure simulated messages are selected from distinct agents by de-duplicating the message `pool` into `uniquePool` and sampling 2–3 entries from that set (modified `pages/consendus.js`).
- Preserved the existing typing-delay and staged emission pipeline used by `appendSimulatedMessages` while integrating the dedupe and timer cleanup logic.

### Testing
- Ran `npm run build` which failed due to pre-existing syntax errors in unrelated files `pages/lumiere.js` and `pages/mealcycle.js`, so a full production build could not complete (failure unrelated to this change).
- Attempted a dev run and automated screenshot using Playwright (`npm run dev` + Playwright) which failed at install time due to an `npm` registry/security policy (`E403`), so the runtime UI snapshot step could not complete.
- Changes were committed (`Refine Consendus comms simulation behavior`) and no unit tests were present or executed for the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a94216508328898f0463c67deff6)