### PR TITLE
Refine Consendus console layout and accessibility

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -759,7 +759,7 @@ await swarm.deploy('migration-api-v2')`}
             />
 
             <aside
-              className={`fixed z-40 h-full w-72 border-r border-white/10 bg-slate-900/95 p-5 backdrop-blur transition-transform md:static md:translate-x-0 ${
+              className={`fixed z-40 h-full w-72 border-r border-white/10 bg-slate-900/95 p-5 backdrop-blur transition-transform md:sticky md:top-0 md:h-screen md:translate-x-0 ${
                 sidebarOpen ? 'translate-x-0' : '-translate-x-full'
               }`}
             >
@@ -809,6 +809,7 @@ await swarm.deploy('migration-api-v2')`}
               <header className="mb-6 flex items-center justify-between">
                 <button
                   onClick={() => setSidebarOpen(true)}
+                  aria-label="Open navigation"
                   className="rounded-xl border border-white/10 bg-slate-800 p-2 md:hidden"
                 >
                   <Menu className="h-4 w-4" />
@@ -825,12 +826,12 @@ await swarm.deploy('migration-api-v2')`}
                 </button>
               </header>
 
-                  <div
-                    className={tabVisible ? 'opacity-100 transition-opacity duration-200' : 'opacity-0 transition-opacity duration-150'}
-                    style={tabVisible ? { animation: 'fadeUp 0.24s ease' } : undefined}
-                  >
-                    {renderTab()}
-                  </div>
+              <div
+                className={tabVisible ? 'opacity-100 transition-opacity duration-200' : 'opacity-0 transition-opacity duration-150'}
+                style={tabVisible ? { animation: 'fadeUp 0.24s ease' } : undefined}
+              >
+                {renderTab()}
+              </div>
             </main>
           </div>
         )}


### PR DESCRIPTION
### Motivation
- Improve the Console UX and accessibility by keeping the dashboard navigation pinned on desktop and clarifying the mobile menu affordance.

### Description
- Make the dashboard sidebar sticky on desktop by updating the aside classes to `md:sticky md:top-0 md:h-screen` in `pages/consendus.js`.
- Add an explicit `aria-label="Open navigation"` to the mobile menu toggle button in `pages/consendus.js` to improve screen reader discoverability.
- Normalize the tab content wrapper indentation to tidy up the JSX structure without changing runtime behavior.

### Testing
- Ran `npm run build`, which failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`); the build failure is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f342cdb3688328a6a4c2abaf54923f)