### PR TITLE
Add channel hints and subtle background glow to Consendus console

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -88,6 +88,13 @@ const channels = [
   { name: '#compliance-vote', members: 4, unread: 2 },
 ]
 
+const channelHints = {
+  '#migration-api-v2': 'Release coordination and canary promotion updates.',
+  '#security-audit': 'Policy checks, signatures, and threat findings.',
+  '#platform-rollout': 'Regional rollout status across control-plane clusters.',
+  '#compliance-vote': 'Consensus ballots for high-risk orchestration decisions.',
+}
+
 const initialMessages = [
   {
     id: 1,
@@ -531,6 +538,9 @@ export default function Consendus() {
                   </button>
                 ))}
               </div>
+              <p className="mt-4 rounded-lg border border-white/10 bg-slate-900/70 p-2.5 text-xs text-slate-400">
+                {channelHints[activeChannel]}
+              </p>
             </aside>
 
             <div className="rounded-xl border border-white/10 bg-slate-800/70 p-4 backdrop-blur">
@@ -693,6 +703,7 @@ export default function Consendus() {
         style={{ fontFamily: 'Inter, system-ui, -apple-system, sans-serif' }}
       >
         <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.15),transparent_42%)]" />
+        <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(168,85,247,0.08),transparent_36%)]" />
         {!inConsole ? (
           <main
             className={`mx-auto max-w-6xl px-4 py-12 transition-all duration-300 sm:px-6 lg:px-8 ${


### PR DESCRIPTION
### Motivation
- Improve operator UX and visual polish for the Comms view and overall dark-mode glassmorphism aesthetic so the console reads more like a polished developer tool.

### Description
- Added a `channelHints` mapping and render of contextual helper copy under the channel list in the Comms view to show each channel's operational purpose (file: `pages/consendus.js`).
- Added a second subtle radial background gradient layer in the app shell to strengthen the dark-mode glassmorphism look (file: `pages/consendus.js`).

### Testing
- Ran `npm run build`, which exercised the change but the build failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`); the changes are isolated to `pages/consendus.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ec233b1083289cda647744e429fc)