### PR TITLE
Enhance Cuecrew landing persona visualization

### DIFF
--- a/cuecrew-ai/src/LandingPage.tsx
+++ b/cuecrew-ai/src/LandingPage.tsx
@@ -70,6 +70,12 @@ export default function LandingPage({ onLaunch }: { onLaunch: () => void }) {
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <p className="text-sm">{persona.name}</p>
+                    <span
+                      className="mt-1 inline-block rounded-full px-2 py-0.5 text-[10px] font-medium text-black"
+                      style={{ backgroundColor: persona.color }}
+                    >
+                      Live persona
+                    </span>
                     <p className="text-xs text-[var(--color-text-dim)]">{persona.sample}</p>
                   </div>
                   <SineBars />


### PR DESCRIPTION
### Motivation
- Improve clarity of the landing-page crew visualizer by making each AI persona's role visually explicit and color-coded.

### Description
- Add a small color-coded `Live persona` tag to each animated persona card in `cuecrew-ai/src/LandingPage.tsx`, using the persona's configured color for the tag background.

### Testing
- Ran `npm run build` in the `cuecrew-ai` package and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b40c2b2c8328b52525e064dafbd6)