### PR TITLE
Fix speech recognition lifecycle in DemoApp

### DIFF
--- a/cuecrew-ai/src/DemoApp.tsx
+++ b/cuecrew-ai/src/DemoApp.tsx
@@ -44,8 +44,13 @@ export default function DemoApp({ onBack }: Props) {
   const [fallbackText, setFallbackText] = useState('');
   const [supportsSpeech, setSupportsSpeech] = useState(true);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const isRecordingRef = useRef(false);
 
   const latestSegment = useMemo(() => segments[segments.length - 1], [segments]);
+
+  useEffect(() => {
+    isRecordingRef.current = isRecording;
+  }, [isRecording]);
 
   useEffect(() => {
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
@@ -75,12 +80,12 @@ export default function DemoApp({ onBack }: Props) {
 
     recognition.onerror = () => setIsRecording(false);
     recognition.onend = () => {
-      if (isRecording) recognition.start();
+      if (isRecordingRef.current) recognition.start();
     };
 
     recognitionRef.current = recognition;
     return () => recognition.stop();
-  }, [isRecording]);
+  }, []);
 
   const pushFinalSegment = async (text: string) => {
     if (!text.trim()) return;


### PR DESCRIPTION
### Motivation
- Prevent the SpeechRecognition `onend` handler from reading stale React closure state which could incorrectly stop auto-restarting the recognizer when recording is still intended.
- Avoid re-creating the speech recognizer on every `isRecording` toggle so lifecycle and event handlers remain stable and cleanup is predictable.

### Description
- Added a synced ref `isRecordingRef` and a small effect to keep it in sync with `isRecording` so callbacks can read the latest intent via `isRecordingRef.current`.
- Updated the `recognition.onend` callback to check `isRecordingRef.current` instead of the `isRecording` closure value.
- Initialized the SpeechRecognition instance once on mount by changing the setup effect dependency array to `[]`, and left the existing cleanup to `recognition.stop()` on unmount.

### Testing
- Ran `npm run build`, which runs `tsc -b` and `vite build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb34367e388328ba12e593923a2d55)