### PR TITLE
Add quick signal cards to Consendus console

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -60,6 +60,12 @@ const stats = [
   { label: 'Token Usage', value: '1.2M', delta: '+4%', icon: Cpu },
 ]
 
+const quickSignals = [
+  { label: 'Consensus Queue', value: '07', tone: 'text-purple-200 border-purple-400/30 bg-purple-500/10' },
+  { label: 'Guard Rails', value: 'Stable', tone: 'text-emerald-200 border-emerald-400/30 bg-emerald-500/10' },
+  { label: 'Latency P95', value: '42ms', tone: 'text-amber-200 border-amber-400/30 bg-amber-500/10' },
+]
+
 const analytics = [
   { time: '00:00', load: 32, tokens: 56 },
   { time: '02:00', load: 41, tokens: 64 },
@@ -863,6 +869,18 @@ await swarm.deploy('migration-api-v2')`}
                   </button>
                 </div>
               </header>
+
+              <section className="mb-5 grid gap-2 sm:grid-cols-3">
+                {quickSignals.map((signal) => (
+                  <article
+                    key={signal.label}
+                    className={`rounded-xl border px-3 py-2 backdrop-blur ${signal.tone}`}
+                  >
+                    <p className="text-[11px] uppercase tracking-wide opacity-80">{signal.label}</p>
+                    <p className="mt-0.5 text-sm font-semibold">{signal.value}</p>
+                  </article>
+                ))}
+              </section>
 
               <div
                 className={tabVisible ? 'opacity-100 transition-opacity duration-200' : 'opacity-0 transition-opacity duration-150'}


### PR DESCRIPTION
### Motivation
- Surface compact, at-a-glance operational signals in the console to improve telemetry density and developer tooling feel for the Consendus dashboard.
- Keep the UI consistent with the existing deep dark theme and glassmorphism styling while providing quick status indicators (consensus queue, guard rails, p95 latency).

### Description
- Added a new mock data array `quickSignals` containing `Consensus Queue`, `Guard Rails`, and `Latency P95` to the Consendus page.
- Rendered a responsive quick-signal card row directly under the console header in `pages/consendus.js` using the existing glassmorphism / dark UI classes.
- The change is isolated to `pages/consendus.js` and only affects the console view layout and mock telemetry surfaces.

### Testing
- Ran `npm run build` to validate the site build; the build failed due to pre-existing syntax errors in unrelated pages: `pages/lumiere.js` and `pages/mealcycle.js`.
- The added `pages/consendus.js` changes did not introduce syntax errors and are isolated from the failing files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cdb143848328b49e0ecf2d41aeab)