### PR TITLE
Add subtle fadeUp animations to Consendus landing features and comms messages

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -592,6 +592,7 @@ export default function Consendus() {
                         ? 'border-purple-400/25 bg-purple-500/10'
                         : 'border-white/10 bg-slate-900/70 hover:border-indigo-400/20'
                     }`}
+                    style={{ animation: 'fadeUp 0.24s ease' }}
                   >
                     <div className="mb-2 flex items-center justify-between text-xs text-slate-400">
                       <span className="inline-flex items-center gap-1.5">
@@ -769,6 +770,7 @@ await swarm.deploy('migration-api-v2')`}
                 <article
                   key={feature.title}
                   className="rounded-xl border border-white/10 bg-[#1e293b]/75 p-5 shadow-lg shadow-black/20 backdrop-blur transition hover:-translate-y-0.5 hover:border-indigo-400/40"
+                  style={{ animation: 'fadeUp 0.36s ease' }}
                 >
                   <div className="flex items-center gap-2 text-white">
                     <feature.icon className="h-4 w-4 text-indigo-300" />


### PR DESCRIPTION
### Motivation
- Improve perceived polish and motion continuity in the Consendus UI by adding subtle entrance animations to key interactive elements.

### Description
- Add an inline `style` with the `fadeUp` animation to chat message cards in `pages/consendus.js` so messages animate when rendered in the Comms view.
- Add a matching `fadeUp` animation to the landing-page feature cards in `pages/consendus.js` to provide a cohesive entrance effect on the Hero/features section.

### Testing
- Ran `npm run build` to validate the change, which executed but the build failed due to pre-existing syntax errors in unrelated files `pages/lumiere.js` and `pages/mealcycle.js` and not because of this change.
- Verified that the modifications are scoped to `pages/consendus.js` and that the project still lints up to the point of the unrelated syntax failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0319e7c7e88328abb4fec1247f3cc8)