### PR TITLE
Add contextual tab metadata and surface active view in Consendus console header

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -211,6 +211,26 @@ const statusLegend = [
   { label: 'Busy', color: 'bg-amber-400' },
   { label: 'Error', color: 'bg-red-500' },
 ]
+
+const tabMeta = {
+  overview: {
+    title: 'Overview',
+    description: 'Live swarm health, throughput, and consensus telemetry.',
+  },
+  comms: {
+    title: 'Comms',
+    description: 'Agent-to-agent collaboration channels with structured updates.',
+  },
+  orchestration: {
+    title: 'Orchestration',
+    description: 'Task execution lanes with explicit consensus checkpoints.',
+  },
+  fleet: {
+    title: 'Agent Fleet',
+    description: 'Directory of autonomous agents, roles, and runtime status.',
+  },
+}
+
 const levelTextColor = {
   SUCCESS: 'text-emerald-300',
   WARN: 'text-amber-300',
@@ -857,7 +877,7 @@ await swarm.deploy('migration-api-v2')`}
             </aside>
 
             <main className="w-full p-4 md:p-8">
-              <header className="mb-6 flex items-center justify-between">
+              <header className="mb-6 flex flex-wrap items-center gap-3">
                 <button
                   onClick={() => setSidebarOpen(true)}
                   aria-label="Open navigation"
@@ -865,6 +885,10 @@ await swarm.deploy('migration-api-v2')`}
                 >
                   <Menu className="h-4 w-4" />
                 </button>
+                <div className="min-w-[220px] md:ml-1">
+                  <p className="text-sm font-semibold text-slate-100">{tabMeta[activeTab].title}</p>
+                  <p className="text-xs text-slate-400">{tabMeta[activeTab].description}</p>
+                </div>
                 <div className="hidden items-center gap-2 text-sm md:flex">
                   <span className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">
                     Cluster healthy


### PR DESCRIPTION
### Motivation
- Improve console wayfinding by surfacing the active view's title and short description in the header so users understand context when switching tabs.

### Description
- Added a `tabMeta` mapping that provides `title` and `description` for each console view (`overview`, `comms`, `orchestration`, `fleet`) in `pages/consendus.js`.
- Updated the console header layout to display the active tab's title and subtitle alongside existing cluster-health and settings controls.
- Adjusted header class usage to `flex-wrap` and spacing to preserve responsive behavior on mobile and desktop.
- No changes to mock data, routes, or other application logic.

### Testing
- Ran `npm run build`; the build failed due to pre-existing syntax errors in unrelated files `pages/lumiere.js` and `pages/mealcycle.js`, and the failures reported are not caused by changes in `pages/consendus.js`.
- Verified the modified `pages/consendus.js` file parses and the header rendering changes are localized to that file in the development environment (no automated unit tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045de14d4c8328968c06b7b59c74cf)