### PR TITLE
Add non-interactive composer placeholder to Consendus comms and overview panels

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -558,6 +558,17 @@ export default function Consendus() {
                   </p>
                 ))}
               </div>
+
+              <div className="mt-4 rounded-xl border border-white/10 bg-slate-900/70 p-3">
+                <div className="mb-2 flex items-center justify-between text-[11px] text-slate-400">
+                  <span>Message {activeChannel}</span>
+                  <span style={{ fontFamily: 'JetBrains Mono, monospace' }}>agents only</span>
+                </div>
+                <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-500">
+                  <MessageSquare className="h-4 w-4 text-slate-500" />
+                  <span className="truncate">Compose update… (prototype input)</span>
+                </div>
+              </div>
             </div>
           </section>
         </ViewContainer>
@@ -619,7 +630,7 @@ export default function Consendus() {
                 </div>
               )}
 
-              <div ref={chatScrollRef} className="mt-4 h-[360px] space-y-3 overflow-auto pr-1">
+              <div ref={chatScrollRef} className="mt-4 h-[320px] space-y-3 overflow-auto pr-1">
                 {channelMessages.map((message) => (
                   <article
                     key={message.id}
@@ -657,6 +668,17 @@ export default function Consendus() {
                     </div>
                   </article>
                 ))}
+              </div>
+
+              <div className="mt-4 rounded-xl border border-white/10 bg-slate-900/70 p-3">
+                <div className="mb-2 flex items-center justify-between text-[11px] text-slate-400">
+                  <span>Message {activeChannel}</span>
+                  <span style={{ fontFamily: 'JetBrains Mono, monospace' }}>agents only</span>
+                </div>
+                <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-500">
+                  <MessageSquare className="h-4 w-4 text-slate-500" />
+                  <span className="truncate">Compose update… (prototype input)</span>
+                </div>
               </div>
             </div>
           </section>


### PR DESCRIPTION
### Motivation
- Improve the Comms UX so the console reads more like a developer chat tool by adding a visual composer area while keeping the prototype fully mock-driven. 
- Preserve layout balance by slightly reducing the chat scroll area height after introducing the new composer UI.

### Description
- Updated `pages/consendus.js` to add a non-functional message composer placeholder panel under the chat feed in the Comms view that shows channel context and a prototype input row. 
- Added the same visual composer block beneath the Terminal Log in the Overview panel to keep the UI consistent across views. 
- Reduced the chat feed height from `h-[360px]` to `h-[320px]` to maintain spacing with the new composer section. 
- All changes are purely presentational and use the existing dark glassmorphism styles and mock data; no interactive input handling or backend wiring was added.

### Testing
- Ran `npm run build` to validate integration and bundling, which exercised the updated `pages/consendus.js` file. 
- Build failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`), so the failure is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0984b191988328a4f45e0a887fb257)