### PR TITLE
Enhance Consendus comms sidebar with live participant chips

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -100,6 +100,13 @@ const channels = [
   { name: '#compliance-vote', members: 4, unread: 2 },
 ]
 
+const channelPresence = {
+  '#migration-api-v2': ['Atlas-Orchestrator', 'Codex-Dev', 'Nova-Observer'],
+  '#security-audit': ['Sentry-Sec', 'Pulse-Mediator'],
+  '#platform-rollout': ['Atlas-Orchestrator', 'Nova-Observer', 'Codex-Dev'],
+  '#compliance-vote': ['Pulse-Mediator', 'Sentry-Sec', 'Atlas-Orchestrator'],
+}
+
 const channelHints = {
   '#migration-api-v2': 'Release coordination and canary promotion updates.',
   '#security-audit': 'Policy checks, signatures, and threat findings.',
@@ -605,6 +612,19 @@ export default function Consendus() {
               <p className="mt-4 rounded-lg border border-white/10 bg-slate-900/70 p-2.5 text-xs text-slate-400">
                 {channelHints[activeChannel]}
               </p>
+              <div className="mt-3 rounded-lg border border-white/10 bg-slate-900/70 p-2.5">
+                <p className="text-[11px] uppercase tracking-wide text-slate-500">Live participants</p>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {(channelPresence[activeChannel] ?? []).map((agent) => (
+                    <span
+                      key={agent}
+                      className="rounded-full border border-emerald-400/25 bg-emerald-500/10 px-2 py-0.5 text-[11px] text-emerald-200"
+                    >
+                      {agent}
+                    </span>
+                  ))}
+                </div>
+              </div>
             </aside>
 
             <div className="rounded-xl border border-white/10 bg-slate-800/70 p-4 backdrop-blur">


### PR DESCRIPTION
### Motivation
- Improve chat context and fidelity in the Comms view by showing which mock agents are currently present in each channel. 
- Provide a lightweight, frontend-only presence signal to make the prototype feel more like an interactive console without adding a backend.

### Description
- Added a new mock map `channelPresence` to `pages/consendus.js` that lists currently present agents per channel. 
- Rendered a "Live participants" panel in the Comms sidebar that maps `channelPresence[activeChannel]` to compact agent chips, preserving the dark/glass styling and typography. 
- Change is frontend-only, uses hardcoded data, and keeps existing animations and layout behavior intact.

### Testing
- Ran the production build with `npm run build`, which failed due to pre-existing syntax errors in unrelated files `pages/lumiere.js` and `pages/mealcycle.js`, not due to the edits in `pages/consendus.js`.
- No additional automated tests were added for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0af90100008328bbef717c333b021f)