### PR TITLE
Refine Consendus overview chart legend rendering

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -528,11 +528,13 @@ export default function Consendus() {
               <div className="mb-4 flex items-center justify-between">
                 <h2 className="text-sm font-medium text-slate-200">System Load vs Token Consumption</h2>
                 <div className="flex items-center gap-3">
-                  <div className="hidden items-center gap-2 text-xs text-slate-400 sm:flex">
-                    <span className="h-2 w-2 rounded-full bg-indigo-400" />
-                    Load
-                    <span className="h-2 w-2 rounded-full bg-emerald-400" />
-                    Tokens
+                  <div className="hidden items-center gap-3 text-xs text-slate-400 sm:flex">
+                    {chartLegends.map((legend) => (
+                      <span key={legend.label} className="inline-flex items-center gap-1.5">
+                        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: legend.color }} />
+                        {legend.label}
+                      </span>
+                    ))}
                   </div>
                   <Gauge className="h-4 w-4 text-indigo-300" />
                 </div>


### PR DESCRIPTION
### Motivation
- Make the Overview card legend data-driven so the displayed legend always matches the configured chart series and is easier to maintain and extend.

### Description
- Replaced the hardcoded Load/Tokens legend in `pages/consendus.js` with a mapped rendering over the existing `chartLegends` array to generate colored dots and labels.
- Preserved existing dark-mode styling and layout while keeping chart behavior unchanged.

### Testing
- Ran `npm run build`, which failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`), so the production build did not complete.
- Ran `npm run lint`, which failed because the repository does not define a `lint` script in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5a56d9908328bf93fe21efe3980e)