### PR TITLE
Enhance Consendus comms code block rendering

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -1,6 +1,8 @@
 import Head from 'next/head'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 import {
   Activity,
   AlertTriangle,
@@ -263,7 +265,9 @@ function MessageBody({ message }) {
   const markdownComponents = {
     p: ({ children }) => <p className="text-sm text-slate-100">{children}</p>,
     strong: ({ children }) => <strong className="font-semibold text-indigo-100">{children}</strong>,
-    code: ({ inline, children }) => {
+    code: ({ inline, className, children }) => {
+      const match = /language-(\w+)/.exec(className || '')
+
       if (inline) {
         return (
           <code
@@ -276,12 +280,21 @@ function MessageBody({ message }) {
       }
 
       return (
-        <pre
-          className="overflow-x-auto rounded-md border border-emerald-400/20 bg-slate-950 p-3 text-emerald-200"
-          style={{ fontFamily: 'JetBrains Mono, monospace' }}
+        <SyntaxHighlighter
+          language={match?.[1] || 'typescript'}
+          style={oneDark}
+          PreTag="div"
+          customStyle={{
+            margin: 0,
+            borderRadius: '0.375rem',
+            border: '1px solid rgba(52, 211, 153, 0.2)',
+            background: '#020617',
+            fontFamily: 'JetBrains Mono, monospace',
+            fontSize: '12px',
+          }}
         >
-          <code>{children}</code>
-        </pre>
+          {String(children).replace(/\n$/, '')}
+        </SyntaxHighlighter>
       )
     },
   }


### PR DESCRIPTION
### Motivation
- Improve readability and visual fidelity of fenced code blocks in the Comms chat to better match the dark developer-tool aesthetic.
- Preserve existing inline code styling and overall message type handling while upgrading block rendering to a proper syntax-highlighter.

### Description
- Added `react-syntax-highlighter` Prism import (`Prism as SyntaxHighlighter`) and `oneDark` style and wired them into the Comms markdown renderer in `MessageBody`.
- Changed the markdown `code` renderer to detect `language-...` from `className` and render fenced blocks via `SyntaxHighlighter` while keeping inline code as a styled `<code>` element with `JetBrains Mono`.
- Kept all existing message types and simulate/chat flows unchanged so only code block presentation was modified.

### Testing
- Ran `npm run build` which failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`), so the repository build did not complete but the `pages/consendus.js` changes are isolated and compatible within that broader failure context.
- Attempted `npm run lint` which failed because the project has no `lint` script defined, so no linter run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a103696f8f0832883a5f332e015eacf)