### PR TITLE
Enhance Consendus prototype interactions and polish

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -279,7 +279,7 @@ function MessageBody({ message }) {
 
       return (
         <pre
-          className="overflow-x-auto rounded-md border border-emerald-400/20 bg-slate-950 p-3 text-emerald-200"
+          className="overflow-x-auto rounded-md border border-emerald-400/20 bg-slate-950 p-3 text-emerald-200 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.08)]"
           style={{ fontFamily: 'JetBrains Mono, monospace' }}
         >
           <code>{children}</code>
@@ -291,7 +291,7 @@ function MessageBody({ message }) {
   if (message.type === 'code') {
     return (
       <pre
-        className="overflow-x-auto rounded-md border border-emerald-400/20 bg-slate-950 p-3 text-emerald-200"
+        className="overflow-x-auto rounded-md border border-emerald-400/20 bg-slate-950 p-3 text-emerald-200 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.08)]"
         style={{ fontFamily: 'JetBrains Mono, monospace' }}
       >
         {message.content}
@@ -349,6 +349,7 @@ export default function Consendus() {
   const [activeChannel, setActiveChannel] = useState(channels[0].name)
   const [messages, setMessages] = useState(initialMessages)
   const [simulating, setSimulating] = useState(false)
+  const [simulationStep, setSimulationStep] = useState('idle')
   const [typingAgents, setTypingAgents] = useState([])
   const chatScrollRef = useRef(null)
   const simulationTimersRef = useRef([])
@@ -473,6 +474,7 @@ export default function Consendus() {
     const generated = uniquePool.sort(() => Math.random() - 0.5).slice(0, targetCount)
 
     setSimulating(true)
+    setSimulationStep('typing')
     setTypingAgents([])
 
     generated.forEach((message, index) => {
@@ -494,6 +496,7 @@ export default function Consendus() {
         if (index === generated.length - 1) {
           scheduleSimulation(() => {
             setSimulating(false)
+            setSimulationStep('idle')
           }, 260)
         }
       }, (index + 1) * 700)
@@ -673,10 +676,14 @@ export default function Consendus() {
                 </button>
               </div>
 
+              <p className="mt-2 text-xs text-slate-500">
+                Simulated runs enqueue 2-3 mock responses with staggered typing delays.
+              </p>
+
               {simulating && (
                 <div className="mt-3 inline-flex items-center gap-2 rounded-md border border-purple-400/30 bg-purple-500/10 px-2.5 py-1 text-xs text-purple-200">
                   <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-purple-300" />
-                  {typingAgents[0] ? `${typingAgents[0]} is typing...` : 'Agent swarm is drafting responses...'}
+                  {typingAgents[0] ? `${typingAgents[0]} is typing...` : simulationStep === 'typing' ? 'Agent swarm is drafting responses...' : 'Simulation complete.'}
                 </div>
               )}
 
@@ -859,7 +866,7 @@ export default function Consendus() {
                 </p>
                 <button
                   onClick={handleAccessConsole}
-                  className="mt-7 inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-400"
+                  className="mt-7 inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                 >
                   Access Console
                   <ChevronRight className="h-4 w-4" />


### PR DESCRIPTION
### Motivation
- Improve the Comms simulation UX so staged typing and completion are communicated clearly during demo runs. 
- Tighten visual polish on code blocks to better match the dark developer-tool aesthetic and improve CTA keyboard focus visibility for accessibility.

### Description
- Added a new state `simulationStep` and updated the simulation flow in `pages/consendus.js` so the UI exposes staged states (`'typing'` / `'idle'`) while simulated messages are enqueued. 
- Updated the simulated-activity banner copy to explain that runs enqueue 2–3 staggered responses and changed the typing indicator text to reflect the `simulationStep` state. 
- Enhanced code-block styling by adding an inset emerald shadow (`shadow-[inset_0_0_0_1px_rgba(16,185,129,0.08)]`) to `pre` blocks to match the dark-mode aesthetic. 
- Added `focus-visible` ring styles to the landing `Access Console` CTA button for keyboard accessibility.

### Testing
- Ran `npm run build`; the build failed due to pre-existing syntax errors in unrelated pages (`pages/lumiere.js` and `pages/mealcycle.js`), so the overall build did not complete. 
- No automated tests were added or modified for this change; the modified `pages/consendus.js` changes are self-contained and exercised by the simulated activity button in the UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1196bfd59c8328bea847cf066206c1)