### PR TITLE
Add task state badges to Orchestration board

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -228,6 +228,13 @@ const statusColors = {
 
 const taskStates = ['Pending', 'In Progress', 'Needs Consensus', 'Completed']
 
+const taskStateBadgeTone = {
+  Pending: 'border-slate-500/40 bg-slate-700/50 text-slate-200',
+  'In Progress': 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  'Needs Consensus': 'border-purple-400/40 bg-purple-500/10 text-purple-200',
+  Completed: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+}
+
 const statusLegend = [
   { label: 'Idle', color: 'bg-emerald-400' },
   { label: 'Busy', color: 'bg-amber-400' },
@@ -766,7 +773,12 @@ export default function Consendus() {
                         {task.id}
                       </p>
                       <p className="mt-1 text-sm text-slate-100">{task.title}</p>
-                      <p className="mt-2 text-xs text-slate-400">Assigned: {task.agent}</p>
+                      <div className="mt-2 flex items-center justify-between gap-2">
+                        <p className="text-xs text-slate-400">Assigned: {task.agent}</p>
+                        <span className={`rounded-full border px-2 py-0.5 text-[10px] font-medium ${taskStateBadgeTone[task.state]}`}>
+                          {task.state}
+                        </span>
+                      </div>
                       {task.state === 'Needs Consensus' && (
                         <div className="mt-3">
                           <div className="mb-1 flex items-center justify-between text-xs text-purple-200">


### PR DESCRIPTION
### Motivation
- Improve at-a-glance clarity of task cards in the Orchestration view by surfacing each task's state alongside assignment information.

### Description
- Added a `taskStateBadgeTone` mapping to centralize badge tone / border / text classes for `Pending`, `In Progress`, `Needs Consensus`, and `Completed` states in `pages/consendus.js`.
- Replaced the single-line assigned text with a compact row that shows `Assigned:` plus a rounded state badge on each task card in the Orchestration board.
- Preserved existing consensus progress bar and vote-count UI for tasks in `Needs Consensus` state.
- Change is contained to `pages/consendus.js` and only affects the Orchestration task card rendering and styling.

### Testing
- Ran `npm run build` to validate the change; the build process exercised the updated page but the overall build failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`), not because of the `consendus` changes.
- The modified `pages/consendus.js` compiles locally in isolation and UI behavior (badges, layout, and consensus progress bar) were exercised during manual preview steps prior to the full build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d76c8684832895a8266dbce5003e)