### PR TITLE
Fix Consendus markdown code-block JSX and remove unused syntax-highlighter imports

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -1,8 +1,6 @@
 import Head from 'next/head'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
-import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 import {
   Activity,
   AlertTriangle,
@@ -287,7 +285,7 @@ function MessageBody({ message }) {
           style={{ fontFamily: 'JetBrains Mono, monospace' }}
         >
           {String(children).replace(/\n$/, '')}
-        </SyntaxHighlighter>
+        </pre>
       )
     },
   }


### PR DESCRIPTION
### Motivation
- The Comms markdown renderer in `pages/consendus.js` used a mismatched JSX closing tag which caused a compilation error and prevented the Consendus prototype from building.

### Description
- Removed now-unused `react-syntax-highlighter` imports from `pages/consendus.js`.
- Replaced the invalid `</SyntaxHighlighter>` closing tag with a proper `</pre>` in the markdown `code` component so code blocks render as a styled `<pre>` element.
- Kept the existing inline `<code>` styling and preserved the JetBrains Mono font usage for code blocks.

### Testing
- Ran `npm run build` and confirmed the previous JSX error originating from `pages/consendus.js` is resolved and this page now compiles.
- The repository build still fails due to unrelated syntax errors in `pages/lumiere.js` and `pages/mealcycle.js`, which are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142ea264308328b7b6f8d5110ee47b)