### PR TITLE
Fix Consendus markdown code block rendering

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -289,9 +289,18 @@ function MessageBody({ message }) {
       }
 
       return (
-        <pre
-          className="overflow-x-auto rounded-md border border-emerald-400/20 bg-slate-950 p-3 text-emerald-200 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.08)]"
-          style={{ fontFamily: 'JetBrains Mono, monospace' }}
+        <SyntaxHighlighter
+          language={match?.[1] ?? 'typescript'}
+          style={oneDark}
+          customStyle={{
+            margin: 0,
+            borderRadius: '0.375rem',
+            border: '1px solid rgba(16,185,129,0.2)',
+            background: '#020617',
+            fontFamily: 'JetBrains Mono, monospace',
+            fontSize: '12px',
+            padding: '0.75rem',
+          }}
         >
           {String(children).replace(/\n$/, '')}
         </SyntaxHighlighter>


### PR DESCRIPTION
### Motivation
- The markdown renderer for fenced code blocks returned a mismatched JSX closing tag which caused a parse error and broke the Consendus prototype's code rendering during builds.

### Description
- Replaced the invalid `<pre>...</SyntaxHighlighter>` JSX return with a proper `SyntaxHighlighter` component for non-inline code in `pages/consendus.js`.
- Configured `SyntaxHighlighter` to use the `oneDark` style and custom dark theme properties (font family, padding, border) to match the terminal-like UI.
- Left inline code handling and other message types unchanged to preserve existing chat/message behavior.

### Testing
- Ran `npm run build` and confirmed the parse error in `pages/consendus.js` is resolved, allowing that file to compile successfully.
- The overall Next.js build still fails due to unrelated syntax errors in `pages/lumiere.js` and `pages/mealcycle.js`, which are not part of this change.
- No additional automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a159defe14083288677bc081ee8abcb)