### PR TITLE
Enhance Consendus comms UI polish for swarm console prototype

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -264,6 +264,15 @@ const levelTextColor = {
   INFO: 'text-indigo-200',
 }
 
+const agentAccent = {
+  'Atlas-Orchestrator': 'from-indigo-500/30 to-indigo-300/20 text-indigo-100',
+  'Codex-Dev': 'from-emerald-500/30 to-emerald-300/20 text-emerald-100',
+  'Sentry-Sec': 'from-amber-500/30 to-amber-300/20 text-amber-100',
+  'Nova-Observer': 'from-sky-500/30 to-sky-300/20 text-sky-100',
+  'Pulse-Mediator': 'from-purple-500/30 to-purple-300/20 text-purple-100',
+  System: 'from-slate-500/40 to-slate-300/20 text-slate-100',
+}
+
 function ViewContainer({ children }) {
   return <section style={{ animation: 'fadeIn 0.32s ease' }}>{children}</section>
 }
@@ -287,12 +296,17 @@ function MessageBody({ message }) {
       }
 
       return (
-        <pre
-          className="overflow-x-auto rounded-md border border-emerald-400/20 bg-slate-950 p-3 text-emerald-200 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.08)]"
-          style={{ fontFamily: 'JetBrains Mono, monospace' }}
-        >
-          {String(children).replace(/\n$/, '')}
-        </pre>
+        <div className="overflow-hidden rounded-md border border-emerald-400/20 bg-slate-950 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.08)]">
+          <div className="border-b border-emerald-400/20 bg-emerald-500/10 px-3 py-1 text-[10px] uppercase tracking-[0.2em] text-emerald-200">
+            {match?.[1] || 'code'}
+          </div>
+          <pre
+            className="overflow-x-auto p-3 text-emerald-200"
+            style={{ fontFamily: 'JetBrains Mono, monospace' }}
+          >
+            {String(children).replace(/\n$/, '')}
+          </pre>
+        </div>
       )
     },
   }
@@ -710,7 +724,10 @@ export default function Consendus() {
                     style={{ animation: 'fadeUp 0.24s ease' }}
                   >
                     <div className="mb-2 flex items-center justify-between text-xs text-slate-400">
-                      <span className="inline-flex items-center gap-1.5">
+                      <span className="inline-flex items-center gap-2">
+                        <span className={`inline-flex h-5 w-5 items-center justify-center rounded-md bg-gradient-to-br text-[10px] font-semibold ${agentAccent[message.author] ?? 'from-slate-500/40 to-slate-300/20 text-slate-100'}`}>
+                          {message.author.slice(0, 2).toUpperCase()}
+                        </span>
                         {message.type === 'alert' ? <AlertTriangle className="h-3.5 w-3.5 text-amber-300" /> : null}
                         {message.type === 'action' ? <Sparkles className="h-3.5 w-3.5 text-purple-300" /> : null}
                         {message.author}


### PR DESCRIPTION
### Motivation
- Improve scanability of multi-agent chat threads by adding visual identity cues for each agent. 
- Give code blocks a more tool-like, developer-console appearance to match the product aesthetic. 
- Keep changes isolated to the Consendus prototype page and avoid behavioral regressions. 

### Description
- Add an `agentAccent` map and render per-agent gradient avatar chips (initials + accent) in the comms chat feed to make authors easier to identify. 
- Replace inline code-block rendering with a compact, terminal-like language header strip plus rounded code panel using `JetBrains Mono` styling. 
- Update `MessageBody` and the chat message header markup in `pages/consendus.js` to incorporate the new avatar chips and improved code block presentation. 
- Preserve existing simulated activity, tab transitions, typing indicators, and mobile sidebar behavior. 

### Testing
- Ran `npm run build` to validate the change as part of a production build, which completed but ultimately failed due to pre-existing syntax errors in unrelated pages (`pages/lumiere.js` and `pages/mealcycle.js`), not from changes in `pages/consendus.js`. 
- Confirmed the Consendus page updates are syntactically correct and the UI changes are contained to `pages/consendus.js` (no API or data-model changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1833a1be848328b300f41f09d6a2d8)