### PR TITLE
Fix Consendus markdown code rendering

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -287,20 +287,12 @@ function MessageBody({ message }) {
       }
 
       return (
-        <SyntaxHighlighter
-          language={match?.[1] ?? 'typescript'}
-          style={oneDark}
-          customStyle={{
-            margin: 0,
-            borderRadius: '0.375rem',
-            border: '1px solid rgba(16,185,129,0.2)',
-            background: '#020617',
-            fontFamily: 'JetBrains Mono, monospace',
-            fontSize: '12px',
-            padding: '0.75rem',
-          }}
+        <pre
+          className="overflow-x-auto rounded-md border border-emerald-400/20 bg-slate-950 p-3 text-xs text-emerald-200 shadow-[inset_0_0_0_1px_rgba(16,185,129,0.08)]"
+          data-language={match?.[1] ?? 'typescript'}
+          style={{ fontFamily: 'JetBrains Mono, monospace' }}
         >
-          {String(children).replace(/\n$/, '')}
+          <code>{String(children).replace(/\n$/, '')}</code>
         </pre>
       )
     },


### PR DESCRIPTION
### Motivation
- The chat markdown renderer referenced a missing `SyntaxHighlighter`/`oneDark` setup for fenced code blocks which prevented a clean, dependency-free rendering path and risked compile/runtime issues.

### Description
- Replaced the unresolved `SyntaxHighlighter` block in the `MessageBody` markdown components with a styled native `<pre><code>` block that preserves the dark terminal look and sets `data-language` for potential syntax metadata.
- Kept inline code rendering and other message type handlers unchanged while centralizing code block styles with Tailwind classes and `JetBrains Mono` font.
- The change is localized to `pages/consendus.js` and removes the dependency on an undefined `SyntaxHighlighter` reference for fenced code blocks.

### Testing
- Ran `git diff --check` which reported no issues (success).
- Started the dev server with `npm run dev` and verified `http://localhost:3100/consendus` returned an HTML response with the updated page content (success).
- Ran `npm run build` which failed due to unrelated syntax errors in `pages/lumiere.js` and `pages/mealcycle.js`, and these failures are not caused by the `consendus` change (build failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1986afad28832887e8851835c28c4a)