### PR TITLE
Enhance Consendus.ai dark-mode prototype (landing metrics, nav, consensus radar)

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -77,6 +77,18 @@ const quickSignals = [
   { label: 'Latency P95', value: '42ms', tone: 'text-amber-200 border-amber-400/30 bg-amber-500/10' },
 ]
 
+const trustSignals = [
+  { label: 'Autonomous tasks resolved', value: '18.2k' },
+  { label: 'Consensus decisions audited', value: '99.98%' },
+  { label: 'Policy rollbacks prevented', value: '431' },
+]
+
+const consensusRadar = [
+  { label: 'Quorum health', value: '3/3 validators', tone: 'text-emerald-200', width: '100%' },
+  { label: 'Policy drift', value: '0.04 risk', tone: 'text-emerald-200', width: '12%' },
+  { label: 'Escalation backlog', value: '7 reviews', tone: 'text-amber-200', width: '46%' },
+]
+
 const codeWindowDots = ['bg-red-400', 'bg-amber-300', 'bg-emerald-400']
 
 const analytics = [
@@ -619,6 +631,26 @@ export default function Consendus() {
               </div>
 
               <div className="mt-4 rounded-xl border border-white/10 bg-slate-900/70 p-3">
+                <div className="mb-3 flex items-center justify-between">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Consensus Radar</h3>
+                  <ShieldCheck className="h-4 w-4 text-emerald-300" />
+                </div>
+                <div className="space-y-3">
+                  {consensusRadar.map((item) => (
+                    <div key={item.label}>
+                      <div className="mb-1 flex items-center justify-between text-xs">
+                        <span className="text-slate-400">{item.label}</span>
+                        <span className={item.tone}>{item.value}</span>
+                      </div>
+                      <div className="h-1.5 overflow-hidden rounded-full bg-slate-800">
+                        <div className="h-full rounded-full bg-gradient-to-r from-indigo-400 via-purple-400 to-emerald-300" style={{ width: item.width }} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="mt-4 rounded-xl border border-white/10 bg-slate-900/70 p-3">
                 <div className="mb-2 flex items-center justify-between text-[11px] text-slate-400">
                   <span>Message {activeChannel}</span>
                   <span style={{ fontFamily: 'JetBrains Mono, monospace' }}>agents only</span>
@@ -853,6 +885,10 @@ export default function Consendus() {
     <>
       <Head>
         <title>Consendus.ai · Agent Swarm Infrastructure</title>
+        <meta
+          name="description"
+          content="Consendus.ai is a dark-mode console prototype for orchestrating autonomous AI agent swarms with semantic messaging, consensus voting, and guardian rails."
+        />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link
@@ -872,6 +908,21 @@ export default function Consendus() {
               isEnteringConsole ? 'translate-y-2 opacity-0' : 'translate-y-0 opacity-100'
             }`}
           >
+            <nav className="mb-14 flex items-center justify-between rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3 shadow-2xl shadow-black/10 backdrop-blur">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-500/20 text-indigo-200 ring-1 ring-indigo-300/20">
+                  <Command className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">Consendus.ai</p>
+                  <p className="text-xs text-slate-400">Swarm infrastructure control plane</p>
+                </div>
+              </div>
+              <div className="hidden items-center gap-2 text-xs text-slate-300 sm:flex">
+                <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
+                Live network · 128 agents
+              </div>
+            </nav>
             <section className="grid items-center gap-10 lg:grid-cols-2">
               <div>
                 <p className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-indigo-300">
@@ -898,6 +949,14 @@ export default function Consendus() {
                   Access Console
                   <ChevronRight className="h-4 w-4" />
                 </button>
+                <div className="mt-8 grid gap-3 sm:grid-cols-3">
+                  {trustSignals.map((signal) => (
+                    <div key={signal.label} className="rounded-xl border border-white/10 bg-slate-800/55 p-3 backdrop-blur">
+                      <p className="text-lg font-semibold text-white">{signal.value}</p>
+                      <p className="mt-1 text-[11px] leading-4 text-slate-400">{signal.label}</p>
+                    </div>
+                  ))}
+                </div>
               </div>
 
               <div className="rounded-2xl border border-white/10 bg-[#1e293b]/80 p-5 shadow-2xl shadow-black/25 backdrop-blur">
@@ -1006,6 +1065,25 @@ await swarm.deploy('migration-api-v2')`}
                   )
                 })}
               </nav>
+
+              <div className="mt-8 rounded-2xl border border-white/10 bg-slate-800/55 p-4 text-xs text-slate-400">
+                <div className="flex items-center justify-between text-slate-200">
+                  <span>Semantic bus</span>
+                  <span className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 text-emerald-200">
+                    Online
+                  </span>
+                </div>
+                <div className="mt-3 grid grid-cols-2 gap-2">
+                  <div>
+                    <p className="font-mono text-slate-100">42ms</p>
+                    <p>P95 route</p>
+                  </div>
+                  <div>
+                    <p className="font-mono text-slate-100">9.4k</p>
+                    <p>msg/min</p>
+                  </div>
+                </div>
+              </div>
             </aside>
 
             <main className="w-full p-4 md:p-8">


### PR DESCRIPTION
### Motivation
- Make the Consendus.ai landing and console feel more like a polished developer control plane by surfacing trust metrics, consensus visibility, and a compact top nav. 

### Description
- Added mock trust metrics (`trustSignals`) and a consensus radar dataset (`consensusRadar`) to augment the landing hero and Overview panels. 
- Inserted a compact glassmorphism top navigation bar with live-network indicator and a 3-card trust-metrics strip on the hero. 
- Added an Overview "Consensus Radar" panel (quorum health, policy drift, escalation backlog) under the Terminal Log and a small sidebar "Semantic bus" status widget showing route latency and throughput. 
- Added page-level SEO description meta (`<meta name="description" .../>`) and minor Tailwind style additions; all changes are in `pages/consendus.js`.

### Testing
- Ran `git diff --check` with no whitespace errors reported. 
- Started the dev server with `npm run dev` and verified the page; `curl -I http://127.0.0.1:3007/consendus` returned `200 OK`. 
- Attempted production build with `npm run build`, which failed due to pre-existing unrelated syntax errors in `pages/lumiere.js` and `pages/mealcycle.js` (these errors block a full production build). 
- Attempted `npx playwright --version` to capture screenshots, but Playwright install was blocked by the npm registry (HTTP 403), so end-to-end screenshot capture was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d7f0c0b1c8328880c599dc830d69e)