### PR TITLE
Refine Consendus overview telemetry

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -618,14 +618,18 @@ export default function Consendus() {
                 ))}
               </div>
 
-              <div className="mt-4 rounded-xl border border-white/10 bg-slate-900/70 p-3">
-                <div className="mb-2 flex items-center justify-between text-[11px] text-slate-400">
-                  <span>Message {activeChannel}</span>
-                  <span style={{ fontFamily: 'JetBrains Mono, monospace' }}>agents only</span>
+              <div className="mt-4 grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+                <div className="rounded-xl border border-emerald-400/20 bg-emerald-500/10 p-3">
+                  <p className="text-[11px] uppercase tracking-wide text-emerald-200">Bus heartbeat</p>
+                  <p className="mt-1 text-lg font-semibold text-white">18ms</p>
                 </div>
-                <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-500">
-                  <MessageSquare className="h-4 w-4 text-slate-500" />
-                  <span className="truncate">Compose update… (prototype input)</span>
+                <div className="rounded-xl border border-purple-400/20 bg-purple-500/10 p-3">
+                  <p className="text-[11px] uppercase tracking-wide text-purple-200">Consensus locks</p>
+                  <p className="mt-1 text-lg font-semibold text-white">7 active</p>
+                </div>
+                <div className="rounded-xl border border-amber-400/20 bg-amber-500/10 p-3">
+                  <p className="text-[11px] uppercase tracking-wide text-amber-200">Policy drift</p>
+                  <p className="mt-1 text-lg font-semibold text-white">0.02%</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Replace a small, static "compose" mock in the Overview terminal sidecar with actionable operational telemetry tiles to better showcase runtime signals in the Consendus.ai prototype.
- Keep the dark glassmorphism visual treatment and prototype-only mock data while improving the telemetry affordance for demos.

### Description
- Modified `pages/consendus.js` to remove the previous compose/placeholder sidecar and add a responsive grid of telemetry tiles: `Bus heartbeat`, `Consensus locks`, and `Policy drift` with sample values and visual tones. 
- Kept all existing mock data, layout, chat simulation, orchestration kanban, and agent fleet views intact while preserving the dark-mode styling and animations.
- Committed the change with the message `Refine Consendus overview telemetry`.

### Testing
- Ran `git diff --check` which reported no whitespace or merge conflict markers for this change (success).
- Launched the dev server and verified the route with `curl -I http://127.0.0.1:3000/consendus` which returned HTTP/1.1 200 OK (success).
- Attempted production build with `npm run build`, which failed due to pre-existing syntax errors in unrelated files (`pages/lumiere.js` and `pages/mealcycle.js`) and not because of changes in `pages/consendus.js` (failure due to unrelated files).
- Ran `npx next lint --file pages/consendus.js`, which prompted for ESLint setup because the project has no ESLint config (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2000c840f0832880c86cd48f4c5186)