### PR TITLE
Add Consendus control‑plane telemetry & agent workload meters; fix build blockers

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -77,6 +77,20 @@ const quickSignals = [
   { label: 'Latency P95', value: '42ms', tone: 'text-amber-200 border-amber-400/30 bg-amber-500/10' },
 ]
 
+const controlPlaneSignals = [
+  { label: 'Semantic Bus', value: '42ms p95', tone: 'text-indigo-200', bar: '72%' },
+  { label: 'Consensus Mesh', value: '3 validators', tone: 'text-purple-200', bar: '100%' },
+  { label: 'Guardian Rails', value: '0 drift', tone: 'text-emerald-200', bar: '88%' },
+]
+
+const agentWorkload = {
+  'Atlas-Orchestrator': 34,
+  'Codex-Dev': 81,
+  'Sentry-Sec': 19,
+  'Nova-Observer': 67,
+  'Pulse-Mediator': 92,
+}
+
 const trustSignals = [
   { label: 'Autonomous tasks resolved', value: '18.2k' },
   { label: 'Consensus decisions audited', value: '99.98%' },
@@ -547,6 +561,22 @@ export default function Consendus() {
     if (activeTab === 'overview') {
       return (
         <ViewContainer key={activeTab}>
+          <section className="mb-5 grid gap-3 lg:grid-cols-3">
+            {controlPlaneSignals.map((signal) => (
+              <article key={signal.label} className="rounded-xl border border-white/10 bg-slate-800/55 p-4 backdrop-blur">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="uppercase tracking-[0.25em] text-slate-500">{signal.label}</span>
+                  <span className={signal.tone} style={{ fontFamily: 'JetBrains Mono, monospace' }}>
+                    {signal.value}
+                  </span>
+                </div>
+                <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-slate-950/80">
+                  <div className="h-full rounded-full bg-gradient-to-r from-indigo-400 via-purple-400 to-emerald-300" style={{ width: signal.bar }} />
+                </div>
+              </article>
+            ))}
+          </section>
+
           <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
             {stats.map((stat) => {
               const Icon = stat.icon
@@ -874,6 +904,20 @@ export default function Consendus() {
               <p className="text-sm text-slate-200" style={{ fontFamily: 'JetBrains Mono, monospace' }}>
                 {agent.uptime}
               </p>
+              <div className="mt-3">
+                <div className="mb-1 flex items-center justify-between text-xs">
+                  <span className="text-slate-400">Current workload</span>
+                  <span className="text-slate-200" style={{ fontFamily: 'JetBrains Mono, monospace' }}>
+                    {agentWorkload[agent.name]}%
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-slate-950/80">
+                  <div
+                    className="h-full rounded-full bg-gradient-to-r from-emerald-300 via-amber-300 to-purple-400"
+                    style={{ width: `${agentWorkload[agent.name]}%` }}
+                  />
+                </div>
+              </div>
             </article>
           ))}
         </section>

--- a/pages/hairloss.js
+++ b/pages/hairloss.js
@@ -145,6 +145,21 @@ const goToMarket = [
   },
 ]
 
+const whyNowPoints = [
+  {
+    title: 'Consumer AI trust',
+    detail: 'Users now expect camera-based coaching and personalized recommendations in everyday health workflows.',
+  },
+  {
+    title: 'Telehealth distribution',
+    detail: 'Remote consults make it easier to convert early detection signals into treatment-ready action.',
+  },
+  {
+    title: 'Prevention demand',
+    detail: 'Younger customers are looking for objective tracking before visible thinning becomes emotionally costly.',
+  },
+]
+
 const recommendationTracks = [
   {
     title: 'Medical track',

--- a/pages/lumiere.js
+++ b/pages/lumiere.js
@@ -291,28 +291,26 @@ export default function Supernormal() {
                   <Activity className="h-4 w-4" />
                   live
                 </span>
-              </div>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-slate-900/70 p-6 shadow-lg">
-              <div className="flex items-center gap-2 text-sm text-slate-300">
-                <TerminalSquare className="h-4 w-4" />
-                Terminal Log
-              </div>
-              <div className="no-scrollbar mt-4 max-h-56 space-y-3 overflow-y-auto pr-2 text-xs text-emerald-200">
-                {terminalEvents.map((event) => (
-                  <p key={event} className="font-mono">
-                    {event}
-                  </p>
-                ))}
-              </div>
-              <button
-                onClick={handleSimulate}
-                className="mt-6 flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
-              >
-                <Sparkles className="h-4 w-4" />
-                Simulate Activity
-              </button>
-            </div>
+                <div className="rounded-2xl border border-white/10 bg-slate-900/70 p-6 shadow-lg">
+                  <div className="flex items-center gap-2 text-sm text-slate-300">
+                    <TerminalSquare className="h-4 w-4" />
+                    Terminal Log
+                  </div>
+                  <div className="no-scrollbar mt-4 max-h-56 space-y-3 overflow-y-auto pr-2 text-xs text-emerald-200">
+                    {terminalEvents.map((event) => (
+                      <p key={event} className="font-mono">
+                        {event}
+                      </p>
+                    ))}
+                  </div>
+                  <button
+                    onClick={handleSimulate}
+                    className="mt-6 flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
+                  >
+                    <Sparkles className="h-4 w-4" />
+                    Simulate Activity
+                  </button>
+                </div>
 
                 <div className="rounded-2xl border border-indigo-500/20 bg-indigo-500/10 p-4 text-sm">
                   <p className="text-sm font-semibold">Insight</p>

--- a/pages/mealcycle.js
+++ b/pages/mealcycle.js
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react'
-import { GoogleGenAI } from '@google/genai'
 import {
   Activity,
   ChevronRight,
@@ -22,9 +21,6 @@ const APP_STAGE = {
   DASHBOARD: 'dashboard',
 }
 
-const MEDICATIONS = ['Ozempic', 'Mounjaro', 'Wegovy', 'Zepbound', 'Other']
-const DOSAGE_STAGES = ['Initiation', 'Titration', 'Maintenance']
-
 const STARTING_PROFILE = {
   name: 'Taylor M.',
   medication: 'Ozempic',
@@ -32,12 +28,6 @@ const STARTING_PROFILE = {
   proteinTarget: 120,
 }
 
-const BASE_CHAT = [
-  {
-    role: 'assistant',
-    text: 'Hi! I am your GLP-1 nutrition assistant. Ask me about nausea-safe options, protein timing, or meal sizing.',
-  },
-]
 
 const gradientButton =
   'bg-gradient-to-r from-[#ccfbf1] via-teal-400 to-[#0f766e] text-slate-900 shadow-lg shadow-teal-800/20 hover:opacity-95'
@@ -323,132 +313,6 @@ function MealCard({ meal }) {
   )
 }
 
-function StatCard({ title, value }) {
-  return (
-    <article className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm shadow-slate-200/70">
-      <p className="text-sm text-slate-500">{title}</p>
-      <p className="mt-2 text-2xl font-semibold text-slate-900">{value}</p>
-    </article>
-  )
-}
-
-function ProgressView() {
-  const proteinAvg = Math.round(MOCK_LOGS.reduce((sum, day) => sum + day.protein, 0) / MOCK_LOGS.length)
-  const symptomFreeDays = MOCK_LOGS.filter((item) => item.symptomFree).length
-  const currentWeight = MOCK_LOGS[MOCK_LOGS.length - 1].weight
-
-  return (
-    <div className="space-y-5">
-      <div className="grid gap-4 md:grid-cols-3">
-        <StatCard title="Current Weight" value={`${currentWeight} lb`} />
-        <StatCard title="Daily Protein Avg" value={`${proteinAvg} g`} />
-        <StatCard title="Symptom-Free Days" value={`${symptomFreeDays}`} />
-      </div>
-
-      <div className="h-[340px] rounded-2xl border border-slate-200 bg-white p-4 shadow-md shadow-slate-200/70">
-        <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart data={MOCK_LOGS}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#dbe4ee" />
-            <XAxis dataKey="day" stroke="#64748b" />
-            <YAxis yAxisId="left" stroke="#0f766e" />
-            <YAxis yAxisId="right" orientation="right" stroke="#0f172a" domain={['dataMin - 1', 'dataMax + 1']} />
-            <Tooltip
-              contentStyle={{ borderRadius: '14px', border: '1px solid #cbd5e1', backgroundColor: '#ffffffee' }}
-              labelStyle={{ color: '#0f172a', fontWeight: 600 }}
-            />
-            <Area yAxisId="left" type="monotone" dataKey="protein" fill="#99f6e4" stroke="#0f766e" strokeWidth={2} />
-            <Line yAxisId="right" type="monotone" dataKey="weight" stroke="#0f172a" strokeWidth={3} dot={{ r: 4 }} />
-          </ComposedChart>
-        </ResponsiveContainer>
-      </div>
-    </div>
-  )
-}
-
-function AIChatWidget() {
-  const [input, setInput] = useState('')
-  const [messages, setMessages] = useState(BASE_CHAT)
-  const [loading, setLoading] = useState(false)
-
-  const apiKey = process.env.NEXT_PUBLIC_GEMINI_API_KEY
-
-  const onSubmit = async (event) => {
-    event.preventDefault()
-    const trimmed = input.trim()
-    if (!trimmed || loading) return
-
-    setMessages((prev) => [...prev, { role: 'user', text: trimmed }])
-    setInput('')
-    setLoading(true)
-
-    if (!apiKey) {
-      setMessages((prev) => [
-        ...prev,
-        {
-          role: 'assistant',
-          text: 'Gemini key not configured. Fallback: choose small frequent meals, prioritize lean protein first, stay hydrated, and try bland foods if nausea rises.',
-        },
-      ])
-      setLoading(false)
-      return
-    }
-
-    try {
-      const ai = new GoogleGenAI({ apiKey })
-      const response = await ai.models.generateContent({
-        model: 'gemini-3-flash-preview',
-        contents: trimmed,
-        config: {
-          systemInstruction:
-            'You are an expert nutritionist for GLP-1 patients. Keep answers under 100 words. Focus on protein and symptom management.',
-        },
-      })
-
-      const text = response.text?.trim() || 'Try light meals with protein at each feeding window.'
-      setMessages((prev) => [...prev, { role: 'assistant', text }])
-    } catch (error) {
-      setMessages((prev) => [
-        ...prev,
-        {
-          role: 'assistant',
-          text: 'I could not reach Gemini. Fallback: split meals into small portions, add protein first, and use bland options like oats, yogurt, eggs, and bananas on rough days.',
-        },
-      ])
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  return (
-    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-md shadow-slate-200/70">
-      <h3 className="text-base font-semibold">AI Nutrition Assistant</h3>
-      <div className="mt-3 h-72 space-y-3 overflow-y-auto rounded-xl bg-slate-50 p-3">
-        {messages.map((message, index) => (
-          <div
-            key={`${message.role}-${index}`}
-            className={`max-w-[90%] rounded-2xl px-3 py-2 text-sm ${
-              message.role === 'assistant' ? 'bg-white text-slate-700' : 'ml-auto bg-teal-600 text-white'
-            }`}
-          >
-            {message.text}
-          </div>
-        ))}
-      </div>
-      <form onSubmit={onSubmit} className="mt-3 flex gap-2">
-        <input
-          value={input}
-          onChange={(event) => setInput(event.target.value)}
-          placeholder="I feel nauseous, what should I eat?"
-          className="flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm outline-none focus:border-teal-500"
-        />
-        <button type="submit" className="rounded-xl bg-slate-900 px-3 py-2 text-sm text-white" disabled={loading}>
-          Send
-        </button>
-      </form>
-    </div>
-  )
-}
-
 const ProgressTooltip = ({ active, payload, label }) => {
   if (!active || !payload?.length) return null
   return (
@@ -589,14 +453,14 @@ function Dashboard({ profile, onLogout }) {
           <header className="mb-5 flex flex-wrap items-center justify-between gap-2">
             <div>
               <h2 className="text-2xl font-semibold text-slate-900">
-                {view === DASHBOARD_VIEWS.WEEKLY ? 'Weekly Plan' : 'Progress & Vitals'}
+                {view === 'weekly' ? 'Weekly Plan' : 'Progress & Vitals'}
               </h2>
               <p className="text-sm text-slate-600">Personalized for your GLP-1 journey.</p>
             </div>
-          ) : (
-            <ProgressView />
-          )}
-        </section>
+          </header>
+
+          {view === 'weekly' ? <WeeklyPlanView /> : <ProgressView />}
+        </main>
       </div>
     </div>
   )
@@ -610,8 +474,8 @@ export default function MealcyclePage() {
     return <LandingPage onStart={() => setStage(APP_STAGE.ONBOARDING)} />
   }
 
-  if (stage === APP_STAGES.ONBOARDING) {
-    return <OnboardingFlow profile={profile} setProfile={setProfile} onFinish={() => setStage(APP_STAGES.DASHBOARD)} />
+  if (stage === APP_STAGE.ONBOARDING) {
+    return <OnboardingFlow profile={profile} setProfile={setProfile} onFinish={() => setStage(APP_STAGE.DASHBOARD)} />
   }
 
   return (


### PR DESCRIPTION
### Motivation
- Provide richer, dark‑mode console telemetry for the Consendus prototype so the Overview shows control‑plane health at a glance and the Agent Fleet shows per‑agent workload. 
- Ensure the Next.js production build completes by fixing several preexisting JSX/variable/name issues discovered while integrating the prototype. 

### Description
- Added `controlPlaneSignals` and `agentWorkload` mock data and rendered a glassy health strip on the Overview in `pages/consendus.js`, including gradient status bars and mono font labels. 
- Added per‑agent workload meters to Agent Fleet cards in `pages/consendus.js` that display a percentage and a small progress bar next to uptime. 
- Restored missing `whyNowPoints` data in `pages/hairloss.js` and corrected JSX nesting for the terminal panel in `pages/lumiere.js` to resolve syntax/runtime build errors. 
- Cleaned duplicated/conflicting components and view state logic in `pages/mealcycle.js` (removed unused imports/duplicates and fixed the weekly/progress view conditional) so chart components render without duplicate definitions. 

### Testing
- Ran `npm run build` which produced an optimized production build and completed successfully while emitting non‑fatal warnings about Google font optimization and some Recharts export messages. 
- Ran `git diff --check` (file checks) to confirm no trailing whitespace or patch‑check issues were introduced and it reported clean. 
- Attempted a headless screenshot script (Playwright) to validate the page visually but it failed due to missing `playwright` in the environment; server build and `next dev` both compiled the pages successfully during local dev runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a216f4b2a3c83288d9b41723cc1c6fb)