### PR TITLE
Polish Consendus prototype chart setup

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,6 @@
 /** @type {import('next').NextConfig} */
-const path = require('path')
-
 const nextConfig = {
   reactStrictMode: true,
-  webpack(config) {
-    config.resolve.alias = {
-      ...(config.resolve.alias || {}),
-      recharts: path.resolve(__dirname, 'components/recharts.js'),
-    }
-    return config
-  },
 }
 
 module.exports = nextConfig

--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -938,12 +938,6 @@ export default function Consendus() {
           name="description"
           content="Consendus.ai is a dark-mode console prototype for orchestrating autonomous AI agent swarms with semantic messaging, consensus voting, and guardian rails."
         />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap"
-          rel="stylesheet"
-        />
       </Head>
       <div
         className="min-h-screen bg-[#0f172a] text-slate-100 selection:bg-indigo-500/30"


### PR DESCRIPTION
### Motivation

- Fix the analytics chart rendering so the Consendus prototype uses the real Recharts implementation (grid, axes, tooltip, multi-series areas) instead of a lightweight local mock. 
- Remove duplicated Google Fonts stylesheet tags from the page head and rely on the shared `_document` font setup to avoid redundant injection.

### Description

- Stop aliasing `recharts` to the local mock by removing the custom webpack alias in `next.config.js`, so the installed `recharts` package is used at runtime. 
- Remove duplicate Google Fonts `<link>` tags from the Consendus page head in `pages/consendus.js` and keep page metadata unchanged. 
- Preserve the `AreaChart` analytics implementation on the Consendus dashboard so `CartesianGrid`, `XAxis`, `YAxis`, `Tooltip`, and `Area` series render with the real library.

### Testing

- Ran `npm run build` and the production build completed successfully with a non-fatal warning that Google Fonts stylesheet optimization was skipped. 
- Launched the dev server and fetched the page with `curl` to verify `/consendus` returns the expected HTML and contains the landing copy, which succeeded. 
- Attempted to install/use Playwright for a screenshot, but `npx --yes playwright --version` was blocked by the npm registry with a `403 Forbidden`, so automated screenshot tooling could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29456c57c4832895baf3c05c66439a)