### PR TITLE
Add Consensus Radar panel to Consendus overview

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -695,6 +695,28 @@ export default function Consendus() {
                   <p className="mt-1 text-lg font-semibold text-white">0.02%</p>
                 </div>
               </div>
+
+              <div className="mt-4 rounded-xl border border-white/10 bg-slate-950/40 p-3">
+                <div className="mb-3 flex items-center justify-between">
+                  <p className="text-[11px] uppercase tracking-[0.22em] text-slate-500">Consensus radar</p>
+                  <span className="rounded-full border border-purple-400/30 bg-purple-500/10 px-2 py-0.5 text-[10px] text-purple-200">
+                    guarded
+                  </span>
+                </div>
+                <div className="space-y-3">
+                  {consensusRadar.map((item) => (
+                    <div key={item.label}>
+                      <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+                        <span className="text-slate-400">{item.label}</span>
+                        <span className={item.tone}>{item.value}</span>
+                      </div>
+                      <div className="h-1.5 overflow-hidden rounded-full bg-slate-800">
+                        <div className="h-full rounded-full bg-gradient-to-r from-indigo-400 via-purple-400 to-emerald-300" style={{ width: item.width }} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
           </section>
         </ViewContainer>


### PR DESCRIPTION
### Motivation
- Surface additional consensus telemetry on the Overview panel so operators can quickly see quorum health, policy drift, and escalation backlog in the Consendus console while preserving the dark-mode glassmorphism styling.

### Description
- Adds a new "Consensus radar" card to the Overview layout that iterates `consensusRadar` and renders compact progress bars and values. (modified `pages/consendus.js`)
- Uses existing theme tokens and gradient progress bars to match the dashboard look and places a small status badge (`guarded`) in the card header.
- Keeps all data mocked from the local `consensusRadar` array so the panel is purely presentational and consistent with the rest of the prototype.

### Testing
- Ran `npm run build`, which completed successfully and produced the optimized build artifacts. 
- Started the dev server and the app compiled successfully during local verification. 
- Attempted an automated headless screenshot using Playwright, but the capture failed because Playwright/browser tooling is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d2d6159d883288a5cc541e6215b9c)