### PR TITLE
Polish Consendus console prototype

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -279,6 +279,12 @@ const statusLegend = [
   { label: 'Error', color: 'bg-red-500' },
 ]
 
+const consoleHealth = [
+  { label: 'Region', value: 'us-east-1' },
+  { label: 'Protocol', value: 'MCP/Swarm' },
+  { label: 'Runtime', value: '99.99%' },
+]
+
 const tabMeta = {
   overview: {
     title: 'Overview',
@@ -546,7 +552,7 @@ export default function Consendus() {
           ...prev,
           {
             ...message,
-            id: prev.length + 1,
+            id: `sim-${Date.now()}-${index}`,
             time: formatSimulationTime(index * 60),
           },
         ])
@@ -1223,7 +1229,25 @@ await swarm.deploy('migration-api-v2')`}
                     <p>msg/min</p>
                   </div>
                 </div>
+                <div className="mt-4 space-y-2 border-t border-white/10 pt-3">
+                  {consoleHealth.map((item) => (
+                    <div key={item.label} className="flex items-center justify-between gap-2">
+                      <span>{item.label}</span>
+                      <span className="font-mono text-slate-100">{item.value}</span>
+                    </div>
+                  ))}
+                </div>
               </div>
+
+              <button
+                onClick={() => {
+                  setInConsole(false)
+                  setSidebarOpen(false)
+                }}
+                className="mt-4 w-full rounded-xl border border-white/10 bg-slate-800/70 px-3 py-2 text-sm text-slate-200 transition hover:border-indigo-300/40 hover:text-white md:hidden"
+              >
+                Back to landing
+              </button>
             </aside>
 
             <main className="w-full p-4 md:p-8">


### PR DESCRIPTION
### Motivation
- Improve the Consendus.ai console prototype with more realistic telemetry and mobile-friendly navigation for demos.
- Make simulated chat activity more robust to repeated runs by avoiding ID collisions.

### Description
- Added a `consoleHealth` metadata array and surface it in the console sidebar to show `Region`, `Protocol`, and `Runtime` values in the mobile drawer (file: `pages/consendus.js`).
- Rendered the `consoleHealth` items beneath the existing semantic-bus summary in the sidebar and added a mobile-only `Back to landing` button to improve responsive navigation (file: `pages/consendus.js`).
- Hardened simulated message IDs by switching to unique IDs using ``sim-${Date.now()}-${index}`` when appending simulated chat messages to prevent collisions during repeated simulations (file: `pages/consendus.js`).

### Testing
- Ran the production build with `npm run build`, which completed successfully and generated static pages including the `/consendus` route.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33e37797348328a4decc26c10a0b45)