### PR TITLE
Polish Consendus dark theme defaults

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,19 +3,19 @@
 @tailwind utilities;
 
 :root {
-  background-color: #fdfbf7;
-  color: #2d2a26;
+  background-color: #0f172a;
+  color: #e2e8f0;
 }
 
 ::selection {
-  background-color: rgba(140, 94, 60, 0.24);
-  color: #2d2a26;
+  background-color: rgba(99, 102, 241, 0.3);
+  color: #f8fafc;
 }
 
 body {
   font-family: 'Inter', sans-serif;
-  background-color: #fdfbf7;
-  color: #2d2a26;
+  background-color: #0f172a;
+  color: #e2e8f0;
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
### Motivation
- Ensure the site uses the Consendus.ai deep dark-mode palette globally to avoid light-theme flashes and align selection colors with the indigo/slate design language.

### Description
- Update global CSS defaults in `styles/globals.css` to set dark background (`#0f172a`), light text (`#e2e8f0`), and indigo-styled text selection to match the prototype's theme.

### Testing
- Ran `npm run build`, which completed successfully; Next.js reported warnings that the Google Fonts stylesheet could not be downloaded so font optimization was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a88805c188328b3175a0fe2e775d6)