### PR TITLE
Fix Consendus console health data

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -314,6 +314,13 @@ const statusLegend = [
   { label: 'Error', color: 'bg-red-500' },
 ]
 
+
+const consoleHealth = [
+  { label: 'Validators', value: '3/3' },
+  { label: 'Guard Rails', value: 'Armed' },
+  { label: 'Audit Log', value: 'Signed' },
+]
+
 const fleetHealth = [
   { label: 'Policy coverage', value: '100%', tone: 'text-emerald-200', bar: '100%' },
   { label: 'Signed actions', value: '98.7%', tone: 'text-indigo-200', bar: '98.7%' },


### PR DESCRIPTION
### Motivation
- The Consendus dashboard sidebar referenced `consoleHealth` mock data that was missing, which could prevent the console sidebar from rendering correct health signals.

### Description
- Added `const consoleHealth = [...]` to `pages/consendus.js` providing `Validators`, `Guard Rails`, and `Audit Log` mock entries so the sidebar can render expected signals.

### Testing
- Ran `npm run build` (Next.js build) which completed successfully and generated static pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc53defc08328ac7a99e6a74e4fdf)