### PR TITLE
Fix Consendus console health data

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -77,6 +77,12 @@ const quickSignals = [
   { label: 'Latency P95', value: '42ms', tone: 'text-amber-200 border-amber-400/30 bg-amber-500/10' },
 ]
 
+const consoleHealth = [
+  { label: 'Consensus', value: '96.8%' },
+  { label: 'Policy drift', value: '0.02%' },
+  { label: 'Token window', value: '10s' },
+]
+
 const swarmReadiness = [
   { label: 'Bus partitions', value: '0', helper: 'all shards routable', tone: 'text-emerald-200' },
   { label: 'Consensus SLA', value: '312ms', helper: 'p90 decision latency', tone: 'text-indigo-200' },


### PR DESCRIPTION
### Motivation
- The Consendus console sidebar referenced a missing `consoleHealth` dataset which could cause runtime rendering issues for the semantic bus health panel, so a small mock health payload was added to satisfy the UI.

### Description
- Add a `consoleHealth` array to `pages/consendus.js` containing three mock metrics (`Consensus`, `Policy drift`, `Token window`) used by the sidebar control-plane health panel.

### Testing
- Ran `npm run build` which completed successfully, and a local HTTP smoke check for `/consendus` returned `200`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e50bcbba083288bbe621097412498)