### PR TITLE
Fix Consendus console health sidebar

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -77,6 +77,12 @@ const quickSignals = [
   { label: 'Latency P95', value: '42ms', tone: 'text-amber-200 border-amber-400/30 bg-amber-500/10' },
 ]
 
+const consoleHealth = [
+  { label: 'Consensus rate', value: '96.8%' },
+  { label: 'Policy checks', value: '1.8k/hr' },
+  { label: 'Token window', value: '128 burst' },
+]
+
 const swarmReadiness = [
   { label: 'Bus partitions', value: '0', helper: 'all shards routable', tone: 'text-emerald-200' },
   { label: 'Consensus SLA', value: '312ms', helper: 'p90 decision latency', tone: 'text-indigo-200' },


### PR DESCRIPTION
### Motivation
- Ensure the console sidebar has the health metrics it references so the semantic bus panel renders without relying on undefined data.

### Description
- Add a `consoleHealth` mock dataset and wire it into the Consendus sidebar health panel in `pages/consendus.js` so the semantic bus block shows `Consensus rate`, `Policy checks`, and `Token window` values.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully (warning: Google Fonts stylesheet downloads were skipped during optimization in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d10f4cf408328a2b0910ca5c54f1a)