### PR TITLE
Add missing consoleHealth summary for Consendus sidebar

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -320,6 +320,13 @@ const fleetHealth = [
   { label: 'Human escalations', value: '3 open', tone: 'text-amber-200', bar: '34%' },
 ]
 
+
+const consoleHealth = [
+  { label: 'Quorum', value: '3/3' },
+  { label: 'Policies', value: '187' },
+  { label: 'Regions', value: '5' },
+]
+
 const tabMeta = {
   overview: {
     title: 'Overview',


### PR DESCRIPTION
### Motivation
- The Consendus console sidebar referenced `consoleHealth` but the mock data was not defined, which could lead to undefined values when the console is opened.

### Description
- Add `const consoleHealth = [...]` to `pages/consendus.js` with three summary entries (`Quorum`, `Policies`, `Regions`) so the sidebar can render the health rows.

### Testing
- Ran `npm run build` which completed successfully and the app compiled and generated static pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d10fb266083289b2511a6aabc5f29)