### PR TITLE
Consendus console prototype: add overview health cards and resolve naming collision

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -77,10 +77,10 @@ const quickSignals = [
   { label: 'Latency P95', value: '42ms', tone: 'text-amber-200 border-amber-400/30 bg-amber-500/10' },
 ]
 
-const consoleHealth = [
-  { label: 'Consensus', value: '96.8%' },
-  { label: 'Policy drift', value: '0.02%' },
-  { label: 'Token window', value: '10s' },
+const consoleOverviewHealth = [
+  { label: 'Consensus', value: '96.8%', tone: 'text-indigo-200 border-indigo-400/30 bg-indigo-500/10' },
+  { label: 'Policy Drift', value: '0.02%', tone: 'text-emerald-200 border-emerald-400/30 bg-emerald-500/10' },
+  { label: 'Token Window', value: '10s', tone: 'text-purple-200 border-purple-400/30 bg-purple-500/10' },
 ]
 
 const swarmReadiness = [
@@ -1463,7 +1463,7 @@ await swarm.deploy('migration-api-v2')`}
               </header>
 
               <section className="mb-5 grid gap-2 sm:grid-cols-3">
-                {quickSignals.map((signal) => (
+                {[...quickSignals, ...consoleOverviewHealth].map((signal) => (
                   <article
                     key={signal.label}
                     className={`rounded-xl border px-3 py-2 backdrop-blur ${signal.tone}`}


### PR DESCRIPTION
### Motivation
- Surface concise console health signals in the console header to improve at-a-glance telemetry for the Consendus console UX.
- Resolve a naming collision that prevented rendering duplicate health constants and caused an assembly ambiguity.

### Description
- Renamed the duplicated health data to `consoleOverviewHealth` and added Tailwind tone classes to each signal for consistent dark-mode styling in the header. (file: `pages/consendus.js`)
- Merged the quick operational `quickSignals` with the new `consoleOverviewHealth` for rendering using `[...quickSignals, ...consoleOverviewHealth]` so both sets appear in the console header signal grid. (file: `pages/consendus.js`)
- Adjusted a few label capitalizations to match card presentation and added tone classes so the overview cards visually match the design system. (file: `pages/consendus.js`)

### Testing
- Ran `npm run build`, which completed successfully and generated the static pages without errors.
- Started the dev server (Next.js `next dev`), which compiled client and server successfully during smoke testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40f7c1f9c08328847c0cc4d2e69452)