### PR TITLE
Fix Consendus prototype entrypoint and remove duplicate consoleHealth

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -77,12 +77,6 @@ const quickSignals = [
   { label: 'Latency P95', value: '42ms', tone: 'text-amber-200 border-amber-400/30 bg-amber-500/10' },
 ]
 
-const consoleHealth = [
-  { label: 'Consensus rate', value: '96.8%' },
-  { label: 'Policy checks', value: '1.8k/hr' },
-  { label: 'Token window', value: '128 burst' },
-]
-
 const swarmReadiness = [
   { label: 'Bus partitions', value: '0', helper: 'all shards routable', tone: 'text-emerald-200' },
   { label: 'Consensus SLA', value: '312ms', helper: 'p90 decision latency', tone: 'text-indigo-200' },
@@ -341,12 +335,6 @@ const statusLegend = [
   { label: 'Error', color: 'bg-red-500' },
 ]
 
-
-const consoleHealth = [
-  { label: 'Validators', value: '3/3' },
-  { label: 'Guard Rails', value: 'Armed' },
-  { label: 'Audit Log', value: 'Signed' },
-]
 
 const fleetHealth = [
   { label: 'Policy coverage', value: '100%', tone: 'text-emerald-200', bar: '100%' },

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,3 @@
-import LocalNewsBureau from './local-news'
+import Consendus from './consendus'
 
-export default LocalNewsBureau
+export default Consendus


### PR DESCRIPTION
### Motivation
- Ensure the Consendus.ai landing/console prototype is served from the root path (`/`) for a seamless demo experience.
- Resolve a build/runtime issue caused by duplicate `consoleHealth` constant declarations in the Consendus page.

### Description
- Updated the Next.js root entry to render the prototype by changing `pages/index.js` to `export default Consendus` so the Consendus page is served at `/`.
- Removed duplicate `consoleHealth` declarations in `pages/consendus.js`, leaving a single `consoleHealth` dataset used by the sidebar and overview widgets.
- Preserved the Consendus dark-mode UI, mock data, and interactive simulation logic while cleaning up the redundant constants.

### Testing
- Ran `npm run build` which completed successfully (Next.js emitted external Google Fonts warnings but finished the build).
- Verified the running app responded at the root by running `curl -I http://localhost:3000/` which returned `HTTP/1.1 200 OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4516d2c36c83288474a4a951e6cc02)