### PR TITLE
Fix Consendus console health constants

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -341,13 +341,6 @@ const statusLegend = [
   { label: 'Error', color: 'bg-red-500' },
 ]
 
-
-const consoleHealth = [
-  { label: 'Validators', value: '3/3' },
-  { label: 'Guard Rails', value: 'Armed' },
-  { label: 'Audit Log', value: 'Signed' },
-]
-
 const fleetHealth = [
   { label: 'Policy coverage', value: '100%', tone: 'text-emerald-200', bar: '100%' },
   { label: 'Signed actions', value: '98.7%', tone: 'text-indigo-200', bar: '98.7%' },


### PR DESCRIPTION
### Motivation
- Remove a duplicated `consoleHealth` declaration in `pages/consendus.js` that led to an invalid/ambiguous constant definition and prevented a clean Next.js build.

### Description
- Deleted the redundant `consoleHealth` array so the page has a single, consistent sidebar health config in `pages/consendus.js`.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46572afc7883288aee688acd961bb2)