### PR TITLE
Remove duplicate `competitors` constant in egg-white page

### DIFF
--- a/pages/egg-white-protein-drinks.js
+++ b/pages/egg-white-protein-drinks.js
@@ -83,13 +83,6 @@ const whyNow = [
   'The product has already been de-risked in Greece; the English-speaking market gap is distribution and brand.',
 ]
 
-const competitors = [
-  { name: 'Whey RTD incumbents', note: 'Premier Protein and Fairlife-style brands have scale, but their margin stack is exposed when whey inputs spike.' },
-  { name: 'Plant-based RTDs', note: 'Pea, soy, and oat formats avoid whey, but still fight taste and amino-acid perception versus complete egg white protein.' },
-  { name: 'Egg producers', note: 'The biggest copy risk is a scaled egg company deciding to ship a mainstream RTD before a startup owns the slot.' },
-  { name: 'Egg white powder tubs', note: 'Existing powders serve bakers and hardcore lifters, not the mainstream grab-and-go chilled drink occasion.' },
-]
-
 const risks = [
   'Taste and texture must beat the eggy, chalky reputation of older egg protein formats.',
   'Avian flu can still shock egg supply, so contracts and redundancy matter.',


### PR DESCRIPTION
### Motivation
- Fix a redeclared `competitors` constant in `pages/egg-white-protein-drinks.js` that prevented the page from compiling.

### Description
- Deleted the earlier duplicate `competitors` array from `pages/egg-white-protein-drinks.js`, leaving a single canonical `competitors` definition used by the page.

### Testing
- Ran `npm run build` which completed successfully and produced the static pages (including `/egg-white-protein-drinks`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a576eae8a188328894d87634bc5023c)