### PR TITLE
Fix header Market link and add Tailwind marquee animation

### DIFF
--- a/pages/egg-white-protein-drinks.js
+++ b/pages/egg-white-protein-drinks.js
@@ -146,7 +146,7 @@ export default function EggWhiteProteinDrinks() {
           <nav className="hidden items-center gap-7 text-sm font-semibold text-stone-700 md:flex">
             <a href="#problem" className="hover:text-stone-950">Problem</a>
             <a href="#why-now" className="hover:text-stone-950">Why now</a>
-            <a href="#market" className="hover:text-stone-950">Market</a>
+            <a href="#opportunity" className="hover:text-stone-950">Market</a>
             <a href="#model" className="hover:text-stone-950">Model</a>
             <a href="#launch" className="hover:text-stone-950">Launch</a>
             <a href="#risks" className="hover:text-stone-950">Risks</a>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,10 +31,15 @@ module.exports = {
         fadeIn: {
           '0%': { opacity: 0, transform: 'translateY(8px)' },
           '100%': { opacity: 1, transform: 'translateY(0)' }
+        },
+        marquee: {
+          '0%': { transform: 'translateX(0)' },
+          '100%': { transform: 'translateX(-50%)' }
         }
       },
       animation: {
-        'fade-in': 'fadeIn 0.4s ease-out'
+        'fade-in': 'fadeIn 0.4s ease-out',
+        marquee: 'marquee 22s linear infinite'
       }
     },
   },


### PR DESCRIPTION
### Motivation
- The hero ticker uses an `animate-marquee` utility but Tailwind lacked the corresponding keyframes/animation, causing the marquee to be non-functional.
- The header "Market" nav pointed at `#market` while the page section is `#opportunity`, so the link did not scroll to the intended section.

### Description
- Change the header anchor in `pages/egg-white-protein-drinks.js` from `href="#market"` to `href="#opportunity"` so the Market link scrolls to the existing section.
- Add `marquee` keyframes and a `marquee` animation entry to `tailwind.config.js` to support the hero ticker's `animate-marquee` class.

### Testing
- Ran `npm run build` and the production build completed successfully and generated the site pages.
- The build emitted only non-blocking font-download warnings and produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60ba27cdfc83288215de5c3bc8a231)