### PR TITLE
Launch egg white protein experience at the root route

### DIFF
--- a/pages/egg-white-protein-drinks.js
+++ b/pages/egg-white-protein-drinks.js
@@ -185,7 +185,7 @@ export default function EggWhiteProteinDrinks() {
           <nav className="hidden items-center gap-7 text-sm font-semibold text-stone-700 md:flex">
             <a href="#problem" className="hover:text-stone-950">Problem</a>
             <a href="#why-now" className="hover:text-stone-950">Why now</a>
-            <a href="#opportunity" className="hover:text-stone-950">Market</a>
+            <a href="#market" className="hover:text-stone-950">Market</a>
             <a href="#model" className="hover:text-stone-950">Model</a>
             <a href="#launch" className="hover:text-stone-950">Launch</a>
             <a href="#risks" className="hover:text-stone-950">Risks</a>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,3 @@
-import Consendus from './consendus'
+import EggWhiteProteinDrinks from './egg-white-protein-drinks'
 
-export default Consendus
+export default EggWhiteProteinDrinks


### PR DESCRIPTION
### Motivation
- Make the polished OVO/PROTEIN market-entry experience the application’s default homepage so the egg-white RTD concept is the root route for visitors. 
- Fix a small navigation mismatch so the desktop "Market" link scrolls to the existing market section instead of a non-existent anchor.

### Description
- Replace the default export in `pages/index.js` to render `EggWhiteProteinDrinks` at the root route. 
- Fix the header navigation anchor in `pages/egg-white-protein-drinks.js` by changing the `href` from `#opportunity` to `#market` so it scrolls correctly. 
- Minor commit recorded to persist the changes and keep the homepage consistent with the new entry experience.

### Testing
- Ran `npm run build` which completed successfully, with a warning that Google Fonts stylesheet optimization was skipped because the remote stylesheet could not be downloaded. 
- Verified the homepage renders by fetching `http://127.0.0.1:3000/` with `curl -sSf` and confirmed the egg-white protein experience content appears. 
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7099ddb8248328b2abce67c5812e39)