### PR TITLE
Set egg-white protein concept as homepage and remove duplicate footer

### DIFF
--- a/pages/egg-white-protein-drinks.js
+++ b/pages/egg-white-protein-drinks.js
@@ -551,20 +551,6 @@ export default function EggWhiteProteinDrinks() {
           </div>
         </section>
 
-        <footer className="border-t border-white/10 bg-stone-950 text-white">
-          <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-3">
-              <span className="grid h-10 w-10 place-items-center rounded-full bg-amber-300 font-black text-stone-950">O/</span>
-              <div>
-                <p className="font-black tracking-tight">OVO/PROTEIN</p>
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-stone-400">Protein, hatched.</p>
-              </div>
-            </div>
-            <p className="max-w-xl text-sm leading-6 text-stone-400 sm:text-right">
-              A market concept for the next complete-protein category. Validate formulation, supply, claims, and regulatory requirements before launch.
-            </p>
-          </div>
-        </footer>
       </main>
 
       <footer className="border-t border-white/10 bg-stone-950 text-stone-300">

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,3 @@
-import Consendus from './consendus'
+import EggWhiteProteinDrinks from './egg-white-protein-drinks'
 
-export default Consendus
+export default EggWhiteProteinDrinks


### PR DESCRIPTION
### Motivation
- Make the OVO/PROTEIN egg-white market thesis the repository's primary homepage for immediate visibility. 
- Remove a duplicated footer from the concept page so the landing page ends cleanly with a single brand footer.

### Description
- Replace the default index export in `pages/index.js` to render `pages/egg-white-protein-drinks.js` as the site root. 
- Remove the redundant footer block from `pages/egg-white-protein-drinks.js` so only the main site footer remains. 
- Changes were committed (commit message: "Launch egg white protein concept homepage").

### Testing
- Ran `npm run build` / `next build` which completed successfully and generated static pages (24/24). 
- Started the dev server with `npm run dev` which reported the server as ready on `http://localhost:3000`. 
- Verified the homepage content with `curl` which returned the expected `<title>` and hero text. 
- Ran `git diff --check` and created the commit; no linting or diff errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71d8b0f3e88328a480ba0be0f98534)