### PR TITLE
Polish Consendus control plane overview

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -20,6 +20,7 @@ import {
   Play,
   RadioTower,
   ShieldCheck,
+  ServerCog,
   Sparkles,
   Terminal,
   UserCircle2,
@@ -104,6 +105,7 @@ const readinessChecks = [
   { label: 'Policy coverage', value: '100%', helper: 'Every privileged action is gated before execution.', tone: 'from-emerald-500/20 to-emerald-300/5 text-emerald-200' },
   { label: 'Human escalations', value: '4 open', helper: 'Queued for production-owner review.', tone: 'from-amber-500/20 to-amber-300/5 text-amber-200' },
   { label: 'Autonomy budget', value: '82%', helper: 'Remaining spend for the current swarm objective.', tone: 'from-indigo-500/20 to-purple-300/5 text-indigo-200' },
+  { label: 'Tool permissions', value: '42/42', helper: 'Every agent tool scope is bound to a signed approval policy.', tone: 'from-purple-500/20 to-indigo-300/5 text-purple-200' },
 ]
 
 const analytics = [
@@ -328,7 +330,8 @@ export default function Consendus() {
         <section className="mt-6 grid gap-6 xl:grid-cols-[2fr_1fr]">
           <div className="h-[360px] rounded-xl border border-white/10 bg-slate-800/70 p-4 backdrop-blur"><div className="mb-2 flex items-center justify-between"><div><h2 className="text-sm font-medium text-slate-200">System Load vs Token Consumption</h2><p className="mt-1 text-xs text-slate-500">Normalized utilization · last 14 hours</p></div><Gauge className="h-4 w-4 text-indigo-300" /></div><ResponsiveContainer width="100%" height="88%"><AreaChart data={analytics} margin={{ top: 10, right: 8, left: -20, bottom: 0 }}><defs><linearGradient id="load" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="#6366f1" stopOpacity={0.35} /><stop offset="95%" stopColor="#6366f1" stopOpacity={0.02} /></linearGradient><linearGradient id="tokens" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="#10b981" stopOpacity={0.3} /><stop offset="95%" stopColor="#10b981" stopOpacity={0.03} /></linearGradient></defs><CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.2)" vertical={false} /><XAxis dataKey="time" stroke="#94a3b8" fontSize={11} tickLine={false} axisLine={false} /><YAxis stroke="#94a3b8" fontSize={11} tickLine={false} axisLine={false} /><Tooltip contentStyle={{ backgroundColor: '#0f172a', border: '1px solid rgba(255,255,255,.12)', borderRadius: '10px', color: '#e2e8f0' }} /><Legend iconType="circle" iconSize={7} wrapperStyle={{ fontSize: '11px', color: '#cbd5e1' }} /><Area type="monotone" dataKey="load" name="System Load" stroke="#6366f1" fill="url(#load)" strokeWidth={2} /><Area type="monotone" dataKey="tokens" name="Token Consumption" stroke="#10b981" fill="url(#tokens)" strokeWidth={2} /></AreaChart></ResponsiveContainer></div>
           <div className="space-y-6">
-            <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">{readinessChecks.map((check) => <article key={check.label} className={`rounded-xl border border-white/10 bg-gradient-to-br ${check.tone} p-4 backdrop-blur`}><div className="flex items-center justify-between gap-3"><p className="text-sm font-medium text-slate-100">{check.label}</p><span className="font-mono text-lg font-semibold">{check.value}</span></div><p className="mt-2 text-xs leading-5 text-slate-400">{check.helper}</p></article>)}</div>
+            <div className="rounded-xl border border-indigo-400/20 bg-indigo-500/10 p-4 backdrop-blur"><div className="flex items-center justify-between gap-3"><div><h2 className="text-sm font-medium text-indigo-100">Control Plane Health</h2><p className="mt-1 text-xs leading-5 text-slate-400">Policy, autonomy, and permission posture before the next swarm action.</p></div><ServerCog className="h-5 w-5 text-indigo-300" /></div></div>
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">{readinessChecks.map((check) => <article key={check.label} className={`rounded-xl border border-white/10 bg-gradient-to-br ${check.tone} p-4 backdrop-blur`}><div className="flex items-center justify-between gap-3"><p className="text-sm font-medium text-slate-100">{check.label}</p><span className="font-mono text-lg font-semibold">{check.value}</span></div><p className="mt-2 text-xs leading-5 text-slate-400">{check.helper}</p></article>)}</div>
             <div className="rounded-xl border border-white/10 bg-slate-900/80 p-4">
               <div className="mb-3 flex items-center justify-between">
                 <h2 className="text-sm font-medium text-slate-200">Swarm Topology</h2>


### PR DESCRIPTION
### Motivation
- Improve observability of the Consendus overview by surfacing control-plane health and tool-permission posture so operators can quickly assess readiness before actions.

### Description
- Import `ServerCog` from `lucide-react` and add a new "Control Plane Health" card to the Overview header in `pages/consendus.js`.
- Add a new readiness metric `Tool permissions` to the `readinessChecks` array to reflect tool-scope approval coverage.
- Adjust the readiness checks layout (reduce column count on small screens) and add visual polish (border/tone/backdrop) so the new metric fits cleanly with existing panels.

### Testing
- Ran `npm run build`, which compiled successfully and generated static pages (including `/consendus`).
- Attempted an automated screenshot run using a Node/Playwright script, which failed because `playwright` is not installed in the environment (test aborted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7330cd1ff4832883422357ecb53a31)