### PR TITLE
Polish egg protein page mobile navigation

### DIFF
--- a/pages/egg-white-protein-drinks.js
+++ b/pages/egg-white-protein-drinks.js
@@ -200,6 +200,14 @@ export default function EggWhiteProteinDrinks() {
           </nav>
           <a href="#launch" className="rounded-full bg-stone-950 px-4 py-2 text-xs font-black uppercase tracking-wider text-white md:hidden">Launch plan</a>
         </div>
+        <nav className="no-scrollbar flex gap-5 overflow-x-auto border-t border-amber-900/10 px-6 py-3 text-xs font-black uppercase tracking-[0.16em] text-stone-600 md:hidden" aria-label="Mobile navigation">
+          <a href="#problem" className="shrink-0 hover:text-stone-950">Problem</a>
+          <a href="#why-now" className="shrink-0 hover:text-stone-950">Why now</a>
+          <a href="#market" className="shrink-0 hover:text-stone-950">Market</a>
+          <a href="#model" className="shrink-0 hover:text-stone-950">Model</a>
+          <a href="#launch" className="shrink-0 hover:text-stone-950">Launch</a>
+          <a href="#risks" className="shrink-0 hover:text-stone-950">Risks</a>
+        </nav>
       </header>
 
       <main id="main-content">
@@ -551,20 +559,6 @@ export default function EggWhiteProteinDrinks() {
           </div>
         </section>
 
-        <footer className="border-t border-white/10 bg-stone-950 text-white">
-          <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-3">
-              <span className="grid h-10 w-10 place-items-center rounded-full bg-amber-300 font-black text-stone-950">O/</span>
-              <div>
-                <p className="font-black tracking-tight">OVO/PROTEIN</p>
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-stone-400">Protein, hatched.</p>
-              </div>
-            </div>
-            <p className="max-w-xl text-sm leading-6 text-stone-400 sm:text-right">
-              A market concept for the next complete-protein category. Validate formulation, supply, claims, and regulatory requirements before launch.
-            </p>
-          </div>
-        </footer>
       </main>
 
       <footer className="border-t border-white/10 bg-stone-950 text-stone-300">


### PR DESCRIPTION
### Motivation
- Improve navigation on small screens for the long-form egg-white protein market thesis so readers can jump to key sections quickly.
- Remove a duplicated footer block to leave a single, clear brand and disclaimer at the page end.

### Description
- Add a compact, horizontally scrollable mobile navigation bar under the header with links to `#problem`, `#why-now`, `#market`, `#model`, `#launch`, and `#risks` in `pages/egg-white-protein-drinks.js`.
- Remove the earlier duplicated footer block so the page ends with one consistent brand/disclaimer footer.
- Commit made on branch `work` (file changed: `pages/egg-white-protein-drinks.js`).

### Testing
- ✅ `git diff --check` (no whitespace or diff errors).
- ✅ `npm run build` (Next.js production build completed successfully; page generated at `/egg-white-protein-drinks`).
- ⚠️ `npx --yes playwright@1.54.2 --version` — Playwright download failed due to registry policy (HTTP 403), so automated screenshot capture was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7741b77404832892f8c09951879b7c)