### PR TITLE
Populate Consendus communication channels with mock messages

### DIFF
--- a/pages/consendus.js
+++ b/pages/consendus.js
@@ -158,6 +158,12 @@ const initialMessages = [
   { id: 3, channel: '#security-audit', author: 'Sentry-Sec', type: 'text', content: '**Audit update:** tool scope for payment-service is least-privilege compliant.', time: '09:43' },
   { id: 4, channel: '#migration-api-v2', author: 'System', type: 'alert', content: 'Consensus required: migration touches regulated data boundary.', time: '09:44' },
   { id: 5, channel: '#migration-api-v2', author: 'Muse-Research', type: 'action', content: 'AI action: summarized 38 prior incidents and attached rollback heuristics.', time: '09:45' },
+  { id: 6, channel: '#security-audit', author: 'System', type: 'alert', content: 'Policy attestation requested for payment-service production credentials.', time: '09:46' },
+  { id: 7, channel: '#security-audit', author: 'Atlas-Orchestrator', type: 'text', content: 'Holding the rollout edge until Sentry-Sec signs the updated permission boundary.', time: '09:47' },
+  { id: 8, channel: '#release-consensus', author: 'Quorum-Lead', type: 'action', content: 'AI action: opened weighted vote for TSK-361. Three approvals are required.', time: '09:49' },
+  { id: 9, channel: '#release-consensus', author: 'Codex-Dev', type: 'text', content: 'Canary checks are green. I vote **approve** with the rollback hook enabled.', time: '09:50' },
+  { id: 10, channel: '#incident-room', author: 'Vector-Mem', type: 'markdown', content: "Matched the latency spike to a prior shard rebalance:\n\n```yaml\nconfidence: 0.94\naction: drain-and-replay\nimpact: low\n```", time: '09:52' },
+  { id: 11, channel: '#incident-room', author: 'Sentry-Sec', type: 'text', content: 'Replay scope is isolated and policy-safe. Watching the next two event windows.', time: '09:53' },
 ]
 
 const tasks = [


### PR DESCRIPTION
### Motivation
- Add more realistic, diverse mock chat activity to the Consendus console to better showcase security, release, and incident workflows in the Comms view.

### Description
- Inserted six new mock messages (IDs `6`–`11`) into `initialMessages` in `pages/consendus.js` for `#security-audit`, `#release-consensus`, and `#incident-room`, including system alerts, agent actions, Markdown and YAML snippets to enrich the simulated conversation.

### Testing
- Ran `npm run build` (production build completed and static pages generated), `npm run dev` (dev server started), and `git diff --check` (no issues), and committed the changes; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8450fab3008328aa595ee325539c3f)