### PR TITLE
Feature the egg-white protein thesis on the homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,5 @@
-import Consendus from './consendus'
+// The egg-white protein market thesis is the primary experience for this build.
+// Keep the dedicated route as an alias so shared links continue to work.
+import EggWhiteProteinDrinks from './egg-white-protein-drinks'
 
-export default Consendus
+export default EggWhiteProteinDrinks


### PR DESCRIPTION
### Motivation
- Make the egg-white protein market and launch thesis the primary homepage experience while preserving the `/egg-white-protein-drinks` route as an alias.

### Description
- Replace the homepage export in `pages/index.js` to render `EggWhiteProteinDrinks` by importing `./egg-white-protein-drinks` and exporting it as the default (changed file: `pages/index.js`).

### Testing
- Ran `npm run build` (static pages generated), `git diff --check`, `git status --short`, and a homepage smoke check with `curl -fsS http://localhost:3000`, and started the app with `npm start`; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88456af8448328adbe8cd9cadd6ec4)