### PR TITLE
Make egg-white protein concept the homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,3 @@
-import Consendus from './consendus'
+import EggWhiteProteinDrinks from './egg-white-protein-drinks'
 
-export default Consendus
+export default EggWhiteProteinDrinks


### PR DESCRIPTION
### Motivation
- Surface the OVO/PROTEIN egg-white RTD concept at the site root so the validated `/egg-white-protein-drinks` pitch becomes the default user experience while retaining the dedicated route.

### Description
- Replace the default export in `pages/index.js` to export `EggWhiteProteinDrinks` from `./egg-white-protein-drinks` instead of `Consendus`, making the egg-white concept the homepage.

### Testing
- Ran `npm run build`, which completed successfully and generated static pages; ran `git diff --check`, which reported no issues; and started the app with `npm start`, which reported the server started at `http://localhost:3000`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a897d4b72908328b7b0480d4e3980fb)